### PR TITLE
Enable HTTP authentication by default

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,7 @@
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-') }}",
     "project_short_description": "A short description of the project",
     "code_directory": "modules",
-    "year_from": [ "2019" ],
+    "year_from": "2019",
     "year_to": "{% now 'utc', '%Y' %}",
     "license": ["BSD 2-Clause License", "BSD 3-Clause License", "MIT license", "ISC license", "Apache Software License 2.0", "no"],
     "_extensions": ["jinja2_time.TimeExtension"]

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -52,7 +52,7 @@ setup: ### Setup remote environment
 	neuro cp $(REQUIREMENTS_APT) $(REQUIREMENTS_APT_STORAGE)
 	neuro cp $(REQUIREMENTS_PIP) $(REQUIREMENTS_PIP_STORAGE)
 	neuro exec --no-key-check $(SETUP_NAME) "bash -c 'apt-get update && cat $(REQUIREMENTS_APT_ENV) | xargs -I % apt-get install -y --no-install-recommends % && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*'"
-	neuro exec --no-key-check $(SETUP_NAME) 'pip install -r $(REQUIREMENTS_PIP_ENV)'
+	neuro exec --no-key-check $(SETUP_NAME) "bash -c 'pip install -r $(REQUIREMENTS_PIP_ENV) && pip install ${PROJECT_PATH_ENV}'"
 	neuro --network-timeout 300 job save $(SETUP_NAME) $(CUSTOM_ENV_NAME)
 	neuro kill $(SETUP_NAME)
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -29,6 +29,12 @@ FILEBROWSER_NAME?=filebrowser
 BASE_ENV_NAME?=neuromation/base-2
 CUSTOM_ENV_NAME?=image:neuromation-{{cookiecutter.project_slug}}
 
+# Set it to True (verbatim) to disable HTTP authentication for your jobs
+DISABLE_HTTP_AUTH:=
+ifeq ($(DISABLE_HTTP_AUTH), True)
+	HTTP_AUTH:=--no-http-auth
+endif
+
 
 .PHONY: help
 help:
@@ -52,7 +58,7 @@ setup: ### Setup remote environment
 	neuro cp $(REQUIREMENTS_APT) $(REQUIREMENTS_APT_STORAGE)
 	neuro cp $(REQUIREMENTS_PIP) $(REQUIREMENTS_PIP_STORAGE)
 	neuro exec --no-key-check $(SETUP_NAME) "bash -c 'apt-get update && cat $(REQUIREMENTS_APT_ENV) | xargs -I % apt-get install -y --no-install-recommends % && apt-get clean && apt-get autoremove && rm -rf /var/lib/apt/lists/*'"
-	neuro exec --no-key-check $(SETUP_NAME) "bash -c 'pip install -r $(REQUIREMENTS_PIP_ENV) && pip install ${PROJECT_PATH_ENV}'"
+	neuro exec --no-key-check $(SETUP_NAME) "bash -c 'pip install -r $(REQUIREMENTS_PIP_ENV)'"
 	neuro --network-timeout 300 job save $(SETUP_NAME) $(CUSTOM_ENV_NAME)
 	neuro kill $(SETUP_NAME)
 
@@ -119,7 +125,8 @@ jupyter:  ### Run jupyter job
 	neuro run \
 		--name $(JUPYTER_NAME) \
 		--preset gpu-small \
-		--http 8888 --no-http-auth --detach \
+		--http 8888 --detach \
+		$(HTTP_AUTH) \
 		--browse \
 		--volume $(DATA_PATH_STORAGE):$(DATA_PATH_ENV):ro \
 		--volume $(CODE_PATH_STORAGE):$(CODE_PATH_ENV):rw \
@@ -139,7 +146,8 @@ tensorboard:  ### Run tensorboard job
 		--name $(TENSORBOARD_NAME) \
 		--preset cpu-small \
 		--browse \
-		--http 6006 --no-http-auth --detach \
+		--http 6006 --detach \
+		$(HTTP_AUTH) \
 		--volume $(RESULTS_PATH_STORAGE):$(RESULTS_PATH_ENV):ro \
 		--env PLATFORMAPI_SERVICE_HOST="." \
 		$(CUSTOM_ENV_NAME) \
@@ -154,7 +162,8 @@ filebrowser:  ### Run filebrowser job
 	neuro run \
 		--name $(FILEBROWSER_NAME) \
 		--preset cpu-small \
-		--http 80 --no-http-auth --detach \
+		--http 80 --detach \
+		$(HTTP_AUTH) \
 		--browse \
 		--volume $(PROJECT_PATH_STORAGE):/srv:rw \
 		--env PLATFORMAPI_SERVICE_HOST="." \


### PR DESCRIPTION
Closes #30. 

@mariyadavydova Would you mind updating readme with relevant info? It should say something along the lines "HTTP authentication for your jobs is enabled by default. Set `DISABLE_HTTP_AUTH` to `True` in Makefile to disable. This is dangerous bla-bla-bla".