### PR TITLE
Generate unique project names for each test run

### DIFF
--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -1,3 +1,6 @@
+from .utils import unique_label
+
+
 TIMEOUT_MAKE_SETUP = 6 * 60
 TIMEOUT_MAKE_UPLOAD_CODE = 5
 TIMEOUT_MAKE_CLEAN_CODE = 3
@@ -16,7 +19,8 @@ TIMEOUT_NEURO_PS = 4
 
 # all variables prefixed "MK_" are taken from Makefile (without prefix)
 # Project name is defined in cookiecutter.yaml, from `project_name`
-MK_PROJECT_NAME = "test-project"
+UNIQUE_PROJECT_NAME = f"Test Project {unique_label()}"
+MK_PROJECT_NAME = UNIQUE_PROJECT_NAME.lower().replace(" ", "-").replace("_", " ")
 
 MK_CODE_PATH = "modules"
 MK_DATA_PATH = "data"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -10,9 +10,7 @@ from pathlib import Path
 import pexpect
 import pytest
 
-from tests.utils import inside_dir
-
-from .configuration import (
+from tests.e2e.configuration import (
     MK_CODE_PATH,
     MK_DATA_PATH,
     MK_NOTEBOOKS_PATH,
@@ -24,6 +22,8 @@ from .configuration import (
     TIMEOUT_NEURO_LOGIN,
     UNIQUE_PROJECT_NAME,
 )
+from tests.utils import inside_dir
+
 from .utils import LOGGER_NAME, get_logger, timeout, unique_label
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -22,9 +22,8 @@ from tests.e2e.configuration import (
     TIMEOUT_NEURO_LOGIN,
     UNIQUE_PROJECT_NAME,
 )
-from tests.utils import inside_dir
-
 from tests.e2e.utils import LOGGER_NAME, get_logger, timeout, unique_label
+from tests.utils import inside_dir
 
 
 SUBMITTED_JOBS_FILE_NAME = "submitted_jobs.txt"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -24,7 +24,7 @@ from tests.e2e.configuration import (
 )
 from tests.utils import inside_dir
 
-from .utils import LOGGER_NAME, get_logger, timeout, unique_label
+from tests.e2e.utils import LOGGER_NAME, get_logger, timeout, unique_label
 
 
 SUBMITTED_JOBS_FILE_NAME = "submitted_jobs.txt"

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -34,13 +34,13 @@ from .conftest import (
     N_FILES,
     cleanup_local_dirs,
     get_logger,
-    measure_time,
     neuro_ls,
     neuro_ps,
     neuro_rm_dir,
     repeat_until_success,
     run,
 )
+from .utils import measure_time
 
 
 log = get_logger()

--- a/tests/e2e/utils.py
+++ b/tests/e2e/utils.py
@@ -1,0 +1,56 @@
+import logging
+import signal
+import time
+import typing as t
+from contextlib import contextmanager
+from uuid import uuid4
+
+
+LOGGER_NAME = "e2e"
+
+
+def get_logger() -> logging.Logger:
+    logger = logging.getLogger(LOGGER_NAME)
+    return logger
+
+
+log = get_logger()
+
+
+def unique_label() -> str:
+    return uuid4().hex[:8]
+
+
+@contextmanager
+def timeout(time_s: int) -> t.Iterator[None]:
+    """ source: https://www.jujens.eu/posts/en/2018/Jun/02/python-timeout-function/
+    """
+
+    def raise_timeout(signum: int, frame: t.Any) -> t.NoReturn:
+        raise TimeoutError
+
+    # Register a function to raise a TimeoutError on the signal.
+    signal.signal(signal.SIGALRM, raise_timeout)
+    # Schedule the signal to be sent after ``time``.
+    signal.alarm(time_s)
+
+    try:
+        yield
+    except TimeoutError:
+        log.error(f"TIMEOUT ERROR: {time_s}")
+        raise
+    finally:
+        # Unregister the signal so it won't be triggered
+        # if the timeout is not reached.
+        signal.signal(signal.SIGALRM, signal.SIG_IGN)
+
+
+@contextmanager
+def measure_time(command_name: str = "") -> t.Iterator[None]:
+    log.info("-" * 50)
+    start_time = time.time()
+    yield
+    elapsed_time = time.time() - start_time
+    log.info("=" * 50)
+    log.info(f"  TIME SUMMARY [{command_name}]: {elapsed_time:.2f} sec")
+    log.info("=" * 50)


### PR DESCRIPTION
otherwise any 2 builds interfere and break each other