### PR TITLE
Improve testing patterns

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -66,8 +66,12 @@ LOCAL_SUBMITTED_JOBS_CLEANER_SCRIPT_PATH = LOCAL_ROOT_PATH / CLEANUP_JOBS_SCRIPT
 PEXPECT_DEBUG_OUTPUT_LOGFILE = sys.stdout if os.environ.get("CI") != "true" else None
 
 # note: ERROR, being the most general error, must go the last
-DEFAULT_NEURO_ERROR_PATTERNS = ("404: Not Found", "Status: failed", r"ERROR[^:]*: ")
-DEFAULT_MAKE_ERROR_PATTERNS = ("Makefile:", "make: ", "recipe for target ")
+DEFAULT_NEURO_ERROR_PATTERNS = (
+    r"404: Not Found",
+    r"Status: failed",
+    r"ERROR[^:]*:[^\n]*",
+)
+DEFAULT_MAKE_ERROR_PATTERNS = (r"Makefile:[^\n]*", r"recipe for target[^\n]*")
 DEFAULT_ERROR_PATTERNS = DEFAULT_MAKE_ERROR_PATTERNS + DEFAULT_NEURO_ERROR_PATTERNS
 
 
@@ -437,7 +441,7 @@ def neuro_ls(path: str, timeout: int, ignore_errors: bool = False) -> t.Set[str]
     out = run(
         f"neuro ls {path}",
         timeout_s=timeout,
-        debug=True,
+        debug=False,
         stop_patterns=[] if ignore_errors else list(DEFAULT_NEURO_ERROR_PATTERNS),
     )
     result = set(out.split())

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -102,7 +102,7 @@ def test_make_setup() -> None:
         r"Creating image",
         r"Image created",
         r"Pushing image .+ => .+",
-        r"image://.*",
+        r"image://.+",
         # neuro kill
         "neuro kill",
         r"job\-[^\n]+",
@@ -259,7 +259,7 @@ def test_make_run_something_useful(target: str, path: str, timeout_run: int) -> 
             make_cmd,
             debug=True,
             timeout_s=timeout_run,
-            expect_patterns=[r"Status:[^\n]+running"],
+            expect_patterns=[r"Status:[^\n]*running"],
             stop_patterns=DEFAULT_ERROR_PATTERNS,
         )
         search = re.search(r"Http URL.*: (https://.+neu\.ro)", output)
@@ -269,7 +269,7 @@ def test_make_run_something_useful(target: str, path: str, timeout_run: int) -> 
     repeat_until_success(
         f"curl --fail {url}{path}",
         expect_patterns=["<html.*>"],
-        stop_patterns=["curl: "],
+        stop_patterns=[r"curl:[^\n]*"],
     )
 
     make_cmd = f"make kill-{target}"


### PR DESCRIPTION
Use `[^\n]` instead of `.` in stop-patterns so that more information is caught in messages like `ERROR: ...\r\n`