### PR TITLE
Fix error with testing packages version conflict

### DIFF
--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -52,4 +52,4 @@ PROJECT_PIP_FILE_NAME = "requirements.txt"
 
 # note: apt package 'expect' requires user input during installation
 PACKAGES_APT_CUSTOM = ["python", "expect", "figlet"]
-PACKAGES_PIP_CUSTOM = ["aiohttp==3.6", "aiohttp_security==0.4.0", "neuromation"]
+PACKAGES_PIP_CUSTOM = ["aiohttp==3.6", "aiohttp_security", "neuromation==19.9.10"]


### PR DESCRIPTION
Currently we install via pip:
`PACKAGES_PIP_CUSTOM = ["aiohttp==3.6", "aiohttp_security==0.4.0", "neuromation"]`
Since today night, when `neuromation==19.9.23` that depends on `aiohttp==3.6.1` was released, we got an error:
`ERROR: neuromation 19.9.23 has requirement aiohttp>=3.6.1, but you'll have aiohttp 3.6.0 which is incompatible.`
This error is detected with pattern `r"ERROR[^:]*: "` and the test on `make setup` fails.