### PR TITLE
Retry only usually-failing tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ test_unit:
 
 .PHONY: test_e2e_dev
 test_e2e_dev:
-	TRAINING_MACHINE_TYPE=cpu-small pytest -s --environment=dev --tb=line --reruns=2 tests/e2e
+	TRAINING_MACHINE_TYPE=cpu-small pytest -s --environment=dev --tb=short tests/e2e
 
 .PHONY: test_e2e_staging
 test_e2e_staging:
-	TRAINING_MACHINE_TYPE=gpu-small pytest -s --environment=staging --tb=line --reruns=2 tests/e2e
+	TRAINING_MACHINE_TYPE=gpu-small pytest -s --environment=staging --tb=short tests/e2e

--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -132,11 +132,12 @@ PEXPECT_DEBUG_OUTPUT_LOGFILE = (
     if os.environ.get("CI") == "true"
     else sys.stdout
 )
-# note: ERROR, being the most general error, must go the last
+# note: ERROR, being the most general error, should go the last
 DEFAULT_NEURO_ERROR_PATTERNS = (
     "404: Not Found",
     r"Status:[^\n]+failed",
     r"ERROR[^:]*: .+",
+    r"Docker API error: .+",
 )
 DEFAULT_MAKE_ERROR_PATTERNS = ("Makefile:.+", "recipe for target .+ failed.+")
 DEFAULT_ERROR_PATTERNS = DEFAULT_MAKE_ERROR_PATTERNS + DEFAULT_NEURO_ERROR_PATTERNS

--- a/tests/e2e/helpers/runners.py
+++ b/tests/e2e/helpers/runners.py
@@ -22,11 +22,52 @@ from tests.e2e.helpers.utils import log_errors_and_finalize, timeout
 def run(
     cmd: str,
     *,
+    attempts: int = 1,
     timeout_s: int = DEFAULT_TIMEOUT_LONG,
     expect_patterns: t.Sequence[str] = (),
     error_patterns: t.Sequence[str] = DEFAULT_ERROR_PATTERNS,
     verbose: bool = True,
     detect_new_jobs: bool = True,
+) -> str:
+    """
+    This procedure wraps method `_run`. If an exception raised, it repeats to run
+    it so that overall the command `cmd` is executed not more than `attempts` times.
+    """
+    errors: t.List[Exception] = []
+    try:
+        while True:
+            try:
+                return _run(
+                    cmd,
+                    expect_patterns=expect_patterns,
+                    error_patterns=error_patterns,
+                    verbose=verbose,
+                    detect_new_jobs=detect_new_jobs,
+                    timeout_s=timeout_s,
+                )
+            except Exception as e:
+                errors.append(e)
+                num_retries = len(errors)
+                if num_retries == attempts:
+                    raise RuntimeError(
+                        f"Failed to run command `{cmd}` in {attempts} attempts"
+                    )
+                log_msg(f"Retry #{num_retries}...")
+    finally:
+        if errors:
+            log_msg(f"During retries, collected {len(errors)} errors:")
+            for exc in errors:
+                log_msg(f"    {exc}")
+
+
+def _run(
+    cmd: str,
+    *,
+    expect_patterns: t.Sequence[str] = (),
+    error_patterns: t.Sequence[str] = DEFAULT_ERROR_PATTERNS,
+    verbose: bool = True,
+    detect_new_jobs: bool = True,
+    timeout_s: int = DEFAULT_TIMEOUT_LONG,
 ) -> str:
     """
     This method wraps method `run_once` and accepts all its named arguments.

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -172,6 +172,7 @@ def test_make_upload_code() -> None:
         run(
             make_cmd,
             verbose=True,
+            attempts=3,
             timeout_s=TIMEOUT_MAKE_UPLOAD_CODE,
             expect_patterns=[rf"'file://.*/{MK_CODE_PATH}' DONE"],
             # TODO: add upload-specific error patterns

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -81,7 +81,7 @@ def test_make_setup(tmp_path: Path) -> None:
     _run_make_setup_test(tmp_path)
 
 
-@try_except_finally(f"neuro kill {MK_SETUP_NAME}", "neuro kill-jupyter")
+@try_except_finally(f"neuro kill {MK_SETUP_NAME}", f"neuro kill {MK_JUPYTER_NAME}")
 def _run_make_setup_test(tmp_path: Path) -> None:
     project_files_messages = [
         _pattern_copy_file_started(file) for file in PROJECT_PYTHON_FILES


### PR DESCRIPTION
as discussed with @asvetlov , we should retry only tests that usually fail. For now, it's `make setup`. 

NOTE: during `make setup`, the most unstable part is `neuro save`. Firstly, I was planning to split `make setup` into few separate targets so that to test them individually (and re-run only `neuro save` part), but this is non-fair testing. So better test exact `make setup` and accept the overhead.

TODO: change the retry strategy: retry only when certain patterns found and break otherwise