### PR TITLE
Do not kill all the user's jobs during cleanup

### DIFF
--- a/cleanup_jobs.py
+++ b/cleanup_jobs.py
@@ -46,19 +46,6 @@ def cleanup_jobs_from_file() -> None:
         path.write_text("" + "\n".join(failed_to_kill))
 
 
-def cleanup_active_jobs() -> None:
-    print("Killing active jobs:")
-    output = run("neuro --quiet ps", verbose=True, detect_new_jobs=False)
-    jobs = output.split()
-    if jobs:
-        _dump_jobs("FOUND ACTIVE JOBS", jobs)
-        run(f"bash -c 'neuro kill {' '.join(jobs)}'", detect_new_jobs=False)
-        print("-" * 53)
-        print("Result:")
-        run("neuro ps", verbose=True, detect_new_jobs=False)
-        print("=" * 53)
-
-
 def _dump_jobs(message: str, jobs: t.List[str]) -> None:
     print(f"{message}: {len(jobs)} jobs:")
     for job in jobs:
@@ -67,5 +54,4 @@ def _dump_jobs(message: str, jobs: t.List[str]) -> None:
 
 if __name__ == "__main__":
     print(run("neuro ps", detect_new_jobs=False))
-    cleanup_active_jobs()
     cleanup_jobs_from_file()


### PR DESCRIPTION
this is the last problem of test helpers I know that cause cross-build interference.