### PR TITLE
Fix patterns for copying files

### DIFF
--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -140,3 +140,11 @@ DEFAULT_NEURO_ERROR_PATTERNS = (
 )
 DEFAULT_MAKE_ERROR_PATTERNS = ("Makefile:.+", "recipe for target .+ failed.+")
 DEFAULT_ERROR_PATTERNS = DEFAULT_MAKE_ERROR_PATTERNS + DEFAULT_NEURO_ERROR_PATTERNS
+
+
+def _pattern_copy_file_started(file_name: str) -> str:
+    return f"Copy 'file://.*{file_name}'"
+
+
+def _pattern_copy_file_finished(file_name: str) -> str:
+    return rf"'{file_name}' \d+B"

--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -143,7 +143,7 @@ DEFAULT_ERROR_PATTERNS = DEFAULT_MAKE_ERROR_PATTERNS + DEFAULT_NEURO_ERROR_PATTE
 
 
 def _pattern_copy_file_started(file_name: str) -> str:
-    return f"Copy 'file://.*{file_name}'"
+    return f"Copy[^']+'file://.*{file_name}'"
 
 
 def _pattern_copy_file_finished(file_name: str) -> str:

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -38,6 +38,8 @@ from tests.e2e.configuration import (
     TIMEOUT_NEURO_RMDIR_NOTEBOOKS,
     TIMEOUT_NEURO_RUN_CPU,
     TIMEOUT_NEURO_RUN_GPU,
+    _pattern_copy_file_finished,
+    _pattern_copy_file_started,
 )
 from tests.e2e.helpers.runners import (
     neuro_ls,
@@ -62,7 +64,7 @@ def test_project_structure() -> None:
         "README.md",
         PROJECT_APT_FILE_NAME,
         PROJECT_PIP_FILE_NAME,
-        "setup.cfg",
+        *PROJECT_PYTHON_FILES,
         ".gitignore",
     }
 
@@ -81,7 +83,9 @@ def test_make_setup(tmp_path: Path) -> None:
 
 @try_except_finally(f"neuro kill {MK_SETUP_NAME}")
 def _run_make_setup_test(tmp_path: Path) -> None:
-    project_files_messages = [f"Copy 'file://.*{file}" for file in PROJECT_PYTHON_FILES]
+    project_files_messages = [
+        _pattern_copy_file_started(file) for file in PROJECT_PYTHON_FILES
+    ]
     # TODO: test also pre-installed APT packages
     apt_deps_messages = [
         f"Selecting previously unselected package {entry}"
@@ -101,11 +105,11 @@ def _run_make_setup_test(tmp_path: Path) -> None:
         # copy project files
         *project_files_messages,
         # copy apt.txt
-        f"Copy 'file://.*{PROJECT_APT_FILE_NAME}",
-        rf"'{PROJECT_APT_FILE_NAME}' \d+B",
+        _pattern_copy_file_started(PROJECT_APT_FILE_NAME),
+        _pattern_copy_file_finished(PROJECT_APT_FILE_NAME),
         # copy pep.txt
-        f"Copy 'file://.*{PROJECT_PIP_FILE_NAME}",
-        rf"'{PROJECT_PIP_FILE_NAME}' \d+B",
+        _pattern_copy_file_started(PROJECT_PIP_FILE_NAME),
+        _pattern_copy_file_finished(PROJECT_PIP_FILE_NAME),
         # apt-get install
         *apt_deps_messages,
         # pip install


### PR DESCRIPTION
Pattern `Copy 'file://.*{file_name}'` does not work: if the path is too long, the word `Copy` is followed by a new line char.