### PR TITLE
project_slug with dashes instead of underscores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ format:
 test_unit:
 	pytest -v -s tests/unit
 	cookiecutter --no-input --config-file ./tests/cookiecutter.yaml --output-dir .. .
-	stat ../test_project
+	stat ../test-project
 	python -m doctest tests/e2e/conftest.py
 
 .PHONY: test_e2e_dev

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
     "project_name": "Name of the project",
-    "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
+    "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-').replace('_', '-') }}",
     "code_directory": "modules"
 }

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,21 +1,21 @@
 import re
 import sys
 
-
-MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
-
+PROJECT_REGEX = r'^[-a-zA-Z][-a-zA-Z0-9]+$'
 project_slug = '{{ cookiecutter.project_slug }}'
-module_name = '{{ cookiecutter.code_directory }}'
 
-if not re.match(MODULE_REGEX, project_slug):
+if not re.match(PROJECT_REGEX, project_slug):
     print('ERROR: %s is not a valid project slug. Slug can only contain letters, digits, '
-          'and underscores.' % project_slug)
+          'and dashes.' % project_slug)
     sys.exit(1)
 
 if len(project_slug) > 28:
     print('ERROR: %s is a too long project slug. Maximum length is 28 characters '
           '(e.g., "%s").' % (project_slug, project_slug[:28]))
     sys.exit(1)
+
+MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
+module_name = '{{ cookiecutter.code_directory }}'
 
 if not re.match(MODULE_REGEX, module_name):
     print('ERROR: %s is not a valid Python module name. Module name can only contain '

--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -43,15 +43,14 @@ TIMEOUT_NEURO_KILL = 20
 # Project name is defined in cookiecutter.yaml, from `project_name`
 UNIQUE_PROJECT_NAME = f"Test Project {unique_label()}"
 MK_PROJECT_POSTFIX = UNIQUE_PROJECT_NAME.lower().replace(" ", "-")
-MK_PROJECT_SLUG = MK_PROJECT_POSTFIX.replace("-", "_")
 
 MK_CODE_DIR = "modules"
 MK_DATA_DIR = "data"
 MK_NOTEBOOKS_DIR = "notebooks"
 MK_RESULTS_DIR = "results"
 
-MK_PROJECT_PATH_STORAGE = f"storage:{MK_PROJECT_SLUG}"
-MK_PROJECT_PATH_ENV = f"/{MK_PROJECT_SLUG}"
+MK_PROJECT_PATH_STORAGE = f"storage:{MK_PROJECT_POSTFIX}"
+MK_PROJECT_PATH_ENV = f"/{MK_PROJECT_POSTFIX}"
 
 
 MK_SETUP_JOB = f"setup-{MK_PROJECT_POSTFIX}"
@@ -81,7 +80,7 @@ PROJECT_NOTEBOOKS_DIR_CONTENT = {"Untitled.ipynb", "00_notebook_tutorial.ipynb"}
 
 # == tests constants ==
 
-LOG_FILE_NAME = f"output_{MK_PROJECT_SLUG}.log"
+LOG_FILE_NAME = f"output_{MK_PROJECT_POSTFIX}.log"
 CLEANUP_JOBS_FILE_NAME = "cleanup_jobs.txt"
 CLEANUP_STORAGE_FILE_NAME = "cleanup_storage.txt"
 CLEANUP_SCRIPT_FILE_NAME = "cleanup.sh"

--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -42,25 +42,25 @@ TIMEOUT_NEURO_KILL = 20
 # all variables prefixed "MK_" are taken in Makefile (without prefix)
 # Project name is defined in cookiecutter.yaml, from `project_name`
 UNIQUE_PROJECT_NAME = f"Test Project {unique_label()}"
-MK_PROJECT_POSTFIX = UNIQUE_PROJECT_NAME.lower().replace(" ", "-")
+MK_PROJECT_SLUG = UNIQUE_PROJECT_NAME.lower().replace(" ", "-")
 
 MK_CODE_DIR = "modules"
 MK_DATA_DIR = "data"
 MK_NOTEBOOKS_DIR = "notebooks"
 MK_RESULTS_DIR = "results"
 
-MK_PROJECT_PATH_STORAGE = f"storage:{MK_PROJECT_POSTFIX}"
-MK_PROJECT_PATH_ENV = f"/{MK_PROJECT_POSTFIX}"
+MK_PROJECT_PATH_STORAGE = f"storage:{MK_PROJECT_SLUG}"
+MK_PROJECT_PATH_ENV = f"/{MK_PROJECT_SLUG}"
 
 
-MK_SETUP_JOB = f"setup-{MK_PROJECT_POSTFIX}"
-MK_TRAINING_JOB = f"training-{MK_PROJECT_POSTFIX}"
-MK_JUPYTER_JOB = f"jupyter-{MK_PROJECT_POSTFIX}"
-MK_TENSORBOARD_JOB = f"tensorboard-{MK_PROJECT_POSTFIX}"
-MK_FILEBROWSER_JOB = f"filebrowser-{MK_PROJECT_POSTFIX}"
+MK_SETUP_JOB = f"setup-{MK_PROJECT_SLUG}"
+MK_TRAINING_JOB = f"training-{MK_PROJECT_SLUG}"
+MK_JUPYTER_JOB = f"jupyter-{MK_PROJECT_SLUG}"
+MK_TENSORBOARD_JOB = f"tensorboard-{MK_PROJECT_SLUG}"
+MK_FILEBROWSER_JOB = f"filebrowser-{MK_PROJECT_SLUG}"
 
 MK_BASE_ENV_NAME = "neuromation/base"
-MK_CUSTOM_ENV_NAME = f"image:neuromation-{MK_PROJECT_POSTFIX}"
+MK_CUSTOM_ENV_NAME = f"image:neuromation-{MK_PROJECT_SLUG}"
 
 
 PROJECT_APT_FILE_NAME = "apt.txt"
@@ -80,7 +80,7 @@ PROJECT_NOTEBOOKS_DIR_CONTENT = {"Untitled.ipynb", "00_notebook_tutorial.ipynb"}
 
 # == tests constants ==
 
-LOG_FILE_NAME = f"output_{MK_PROJECT_POSTFIX}.log"
+LOG_FILE_NAME = f"output_{MK_PROJECT_SLUG}.log"
 CLEANUP_JOBS_FILE_NAME = "cleanup_jobs.txt"
 CLEANUP_STORAGE_FILE_NAME = "cleanup_storage.txt"
 CLEANUP_SCRIPT_FILE_NAME = "cleanup.sh"

--- a/tests/unit/test_bake_project.py
+++ b/tests/unit/test_bake_project.py
@@ -7,20 +7,20 @@ from tests.utils import inside_dir
 
 
 def test_project_tree(cookies: t.Any) -> None:
-    result = cookies.bake(extra_context={"project_slug": "test_project"})
+    result = cookies.bake(extra_context={"project_slug": "test-project"})
     assert result.exit_code == 0
     assert result.exception is None
     assert result.project.basename == "test_project"
 
 
 def test_run_flake8(cookies: t.Any) -> None:
-    result = cookies.bake(extra_context={"project_slug": "flake8_compat"})
+    result = cookies.bake(extra_context={"project_slug": "flake8-compat"})
     with inside_dir(str(result.project)):
         subprocess.check_call(["flake8"])
 
 
 def test_project_slug_regex_hook(cookies: t.Any) -> None:
-    result = cookies.bake(extra_context={"project_slug": "test-project"})
+    result = cookies.bake(extra_context={"project_slug": "test_project"})
     assert result.exit_code != 0
     assert isinstance(result.exception, FailedHookException)
 

--- a/tests/unit/test_bake_project.py
+++ b/tests/unit/test_bake_project.py
@@ -10,7 +10,7 @@ def test_project_tree(cookies: t.Any) -> None:
     result = cookies.bake(extra_context={"project_slug": "test-project"})
     assert result.exit_code == 0
     assert result.exception is None
-    assert result.project.basename == "test_project"
+    assert result.project.basename == "test-project"
 
 
 def test_run_flake8(cookies: t.Any) -> None:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -13,7 +13,7 @@ PROJECT_PATH_ENV?=/{{cookiecutter.project_slug}}
 
 ##### JOB NAMES #####
 
-PROJECT_POSTFIX?={{cookiecutter.project_slug.replace('_', '-')}}
+PROJECT_POSTFIX?={{cookiecutter.project_slug}}
 
 SETUP_JOB?=setup-$(PROJECT_POSTFIX)
 TRAINING_JOB?=training-$(PROJECT_POSTFIX)


### PR DESCRIPTION
We use project_slug for the repo name (which is usually with dashes, not underscores) and in job names (where we can't even use underscores).