### PR TITLE
Increase pexpect buffer for test runners

### DIFF
--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -120,7 +120,7 @@ JOB_ID_DECLARATION_PATTERN = re.compile(
 
 # == pexpect config ==
 
-PEXPECT_BUFFER_SIZE_BYTES = 50 * 1024
+PEXPECT_BUFFER_SIZE_BYTES = 100 * 1024
 # use `sys.stdout` to echo everything to standard output
 # use `open('mylog.txt','wb')` to log to a file
 # use `None` to disable logging to console


### PR DESCRIPTION
Getting the following errors locally:
```
   assert "Name: neuromation" in run("pip show neuromation", verbose=False)
E   assert 'Name: neuromation' in "ame: neuromation\r\nVersion: 19.9.23\r\nSummary: Neuromation Platform API client\r\nHome-page: https://neuromation.io... version 19.3.1 is available.\r\nYou should consider upgrading via the 'pip install --upgrade pip' command.\x1b[0m\r\n"
E    +  where "ame: neuromation\r\nVersion: 19.9.23\r\nSummary: Neuromation Platform API client\r\nHome-page: https://neuromation.io... version 19.3.1 is available.\r\nYou should consider upgrading via the 'pip install --upgrade pip' command.\x1b[0m\r\n" = run('pip show neuromation', verbose=False)
```
seems like the first char didn't get into the buffer.