### PR TITLE
Fix uploading: keep directories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,10 +89,7 @@ workflows:
     jobs:
       - test_dev
 
-      - test_staging:
-          filters:
-            branches:
-              only: master
+      - test_staging
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,10 @@ workflows:
     jobs:
       - test_dev
 
-      - test_staging
+      - test_staging:
+          filters:
+            branches:
+              only: master
 
   nightly:
     triggers:

--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -146,3 +146,7 @@ def _pattern_copy_file_started(file_name: str) -> str:
 
 def _pattern_copy_file_finished(file_name: str) -> str:
     return rf"'{file_name}' \d+B"
+
+
+def _pattern_upload_dir(project_slug: str, dir_name: str) -> str:
+    return rf"'(file|storage)://[^']*/{project_slug}/{dir_name}' DONE"

--- a/tests/e2e/helpers/runners.py
+++ b/tests/e2e/helpers/runners.py
@@ -290,7 +290,7 @@ def neuro_ls(path: str) -> t.Set[str]:
     out = run(
         f"neuro ls {path}",
         timeout_s=tests.e2e.configuration.TIMEOUT_NEURO_LS,
-        verbose=False,
+        verbose=True,
         error_patterns=tests.e2e.configuration.DEFAULT_NEURO_ERROR_PATTERNS,
     )
     result = set(out.split())

--- a/tests/e2e/helpers/utils.py
+++ b/tests/e2e/helpers/utils.py
@@ -33,9 +33,12 @@ def cleanup_local_dirs(*dirs: t.Union[str, Path]) -> None:
         else:
             d = d_or_name
         log_msg(f"Cleaning up local directory `{d.absolute()}`")
+        assert d.is_dir(), f"not a dir: {d}"
+        assert d.exists(), f"not exists before cleanup: {d}"
         for f in d.iterdir():
             if f.is_file():
                 f.unlink()
+        assert d.exists(), f"not exists after cleanup: {d}"
         assert not list(d.iterdir()), "directory should be empty here"
 
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -68,6 +68,10 @@ setup: ### Setup remote environment
 		--volume $(PROJECT_PATH_STORAGE):$(PROJECT_PATH_ENV):ro \
 		$(BASE_ENV_NAME) \
 		'sleep 1h'
+	$(NEURO) mkdir $(PROJECT_PATH_STORAGE) | true
+	$(NEURO) mkdir $(PROJECT_PATH_STORAGE)/$(CODE_DIR) | true
+	$(NEURO) mkdir $(PROJECT_PATH_STORAGE)/$(DATA_DIR) | true
+	$(NEURO) mkdir $(PROJECT_PATH_STORAGE)/$(NOTEBOOKS_DIR) | true
 	for file in $(PROJECT_FILES); do $(NEURO) cp ./$$file $(PROJECT_PATH_STORAGE)/$$file; done
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) "bash -c 'export DEBIAN_FRONTEND=noninteractive && $(APT) update && cat $(PROJECT_PATH_ENV)/apt.txt | xargs -I % $(APT) install --no-install-recommends % && $(APT) clean && $(APT) autoremove && rm -rf /var/lib/apt/lists/*'"
 	$(NEURO) exec --no-tty --no-key-check $(SETUP_JOB) "bash -c '$(PIP) -r $(PROJECT_PATH_ENV)/requirements.txt'"
@@ -82,7 +86,7 @@ upload-code:  ### Upload code directory to the platform storage
 
 .PHONY: clean-code
 clean-code:  ### Delete code directory from the platform storage
-	$(NEURO) rm --recursive $(PROJECT_PATH_STORAGE)/$(CODE_DIR)
+	$(NEURO) rm --recursive $(PROJECT_PATH_STORAGE)/$(CODE_DIR)/*
 
 .PHONY: upload-data
 upload-data:  ### Upload data directory to the platform storage
@@ -90,7 +94,7 @@ upload-data:  ### Upload data directory to the platform storage
 
 .PHONY: clean-data
 clean-data:  ### Delete data directory from the platform storage
-	$(NEURO) rm --recursive $(DATA_DIR_STORAGE)
+	$(NEURO) rm --recursive $(DATA_DIR_STORAGE)/*
 
 .PHONY: upload-notebooks
 upload-notebooks:  ### Upload notebooks directory to the platform storage
@@ -102,7 +106,7 @@ download-notebooks:  ### Download notebooks directory from the platform storage
 
 .PHONY: clean-notebooks
 clean-notebooks:  ### Delete notebooks directory from the platform storage
-	$(NEURO) rm --recursive $(PROJECT_PATH_STORAGE)/$(NOTEBOOKS_DIR)
+	$(NEURO) rm --recursive $(PROJECT_PATH_STORAGE)/$(NOTEBOOKS_DIR)/*
 
 .PHONY: upload  ### Upload code, data, and notebooks directories to the platform storage
 upload: upload-code upload-data upload-notebooks


### PR DESCRIPTION
The story: tests on dev [succeed](https://circleci.com/gh/neuromation/cookiecutter-neuro-project/673) and tests on staging [fail](https://circleci.com/gh/neuromation/cookiecutter-neuro-project/674). The symptoms there are that on dev, test `make upload-code` [passes](https://673-204585942-gh.circle-artifacts.com/0/ouptut/output_test-project-004b0540.log) the check of `neuro ls` (search for `'file:///.../test-cookiecutter0/test-project-004b0540/modules' DONE` -- there's no errors there), however on staging, this test [fails](https://674-204585942-gh.circle-artifacts.com/0/ouptut/output_test-project-6d648641.log) that check (search for `'file:///.../test-cookiecutter0/test-project-6d648641/modules' DONE`). 

There are 3 possible sources of the problem:
1. a back-end problem. Not confirmed because when the neuro commands run manually, everything works just fine.
2. a problem with test runners. Most likely the cause is https://github.com/neuromation/cookiecutter-neuro-project/issues/162: we *always* got the 404 error, but we miss these failures on dev. Here, I'm not sure how it depends on the environment (why staging and not dev).
3. Together with the previous theory, the problem seems to be that the make commands accidentally delete folders `data/`, `modules/` etc. This PR fixes this problem.

Another problem was that sometimes the result message on directory upload starts with `storage://.../file.txt` and sometimes with `file://.../file.txt`, fixed.

So: This PR modifies `Makefile`'s delete operations from deleting *the whole* directory `<project>/notebooks` to deleteing *all files* in this directory `<project>/notebooks` (applied to other directories as well). 