### PR TITLE
[Makefile] Rename long variable for preset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ test_unit:
 
 .PHONY: test_e2e_dev
 test_e2e_dev:
-	TRAINING_MACHINE_TYPE=cpu-small NEURO=$(NEURO_COMMAND)  pytest -s -v --environment=dev --tb=short tests/e2e
+	PRESET=cpu-small NEURO=$(NEURO_COMMAND)  pytest -s -v --environment=dev --tb=short tests/e2e
 
 .PHONY: test_e2e_staging
 test_e2e_staging:
-	TRAINING_MACHINE_TYPE=gpu-small NEURO=$(NEURO_COMMAND)  pytest -s -v --environment=staging --tb=short tests/e2e
+	PRESET=gpu-small NEURO=$(NEURO_COMMAND)  pytest -s -v --environment=staging --tb=short tests/e2e
 
 .PHONY: cleanup_e2e
 cleanup_e2e:

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -140,7 +140,7 @@ def test_import_code_in_notebooks() -> None:
 @try_except_finally(f"neuro kill {MK_JUPYTER_JOB}")
 def _run_import_code_in_notebooks_test() -> None:
     out = run(
-        "make jupyter HTTP_AUTH=--no-http-auth TRAINING_MACHINE_TYPE=cpu-small",
+        "make jupyter HTTP_AUTH=--no-http-auth PRESET=cpu-small",
         verbose=True,
         expect_patterns=[r"Status:[^\n]+running"],
         timeout_s=TIMEOUT_NEURO_RUN_CPU,

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -33,7 +33,7 @@ CUSTOM_ENV_NAME?=image:neuromation-$(PROJECT_POSTFIX)
 DATA_DIR_STORAGE?=$(PROJECT_PATH_STORAGE)/$(DATA_DIR)
 
 # The type of the training machine (run `neuro config show` to see the list of available types).
-TRAINING_MACHINE_TYPE?=gpu-small
+PRESET?=gpu-small
 # HTTP authentication (via cookies) for the job's HTTP link.
 # Set `HTTP_AUTH?=--no-http-auth` to disable any authentication.
 # WARNING: removing authentication might disclose your sensitive data stored in the job.
@@ -120,7 +120,7 @@ clean: clean-code clean-data clean-notebooks
 training:  ### Run a training job
 	$(NEURO) run \
 		--name $(TRAINING_JOB) \
-		--preset $(TRAINING_MACHINE_TYPE) \
+		--preset $(PRESET) \
 		--volume $(DATA_DIR_STORAGE):$(PROJECT_PATH_ENV)/$(DATA_DIR):ro \
 		--volume $(PROJECT_PATH_STORAGE)/$(CODE_DIR):$(PROJECT_PATH_ENV)/$(CODE_DIR):ro \
 		--volume $(PROJECT_PATH_STORAGE)/$(RESULTS_DIR):$(PROJECT_PATH_ENV)/$(RESULTS_DIR):rw \
@@ -140,7 +140,7 @@ connect-training:  ### Connect to the remote shell running on the training job
 jupyter: upload-code upload-notebooks ### Run a job with Jupyter Notebook and open UI in the default browser
 	$(NEURO) run \
 		--name $(JUPYTER_JOB) \
-		--preset $(TRAINING_MACHINE_TYPE) \
+		--preset $(PRESET) \
 		--http 8888 \
 		$(HTTP_AUTH) \
 		--browse \

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -79,7 +79,7 @@ you need to change the following line to point to its location. For example:
 
 ### Training machine type
 
-`TRAINING_MACHINE_TYPE?=gpu-small`
+`PRESET?=gpu-small`
 
 There are several machine types supported on the platform. Run `neuro config show` to see the list.
 


### PR DESCRIPTION
`TRAINING_MACHINE_TYPE` -> `PRESET`:
1. I always forget the longer name
2. it looks bulky: `make jupyter TRAINING_MACHINE_TYPE=cpu-small`, instead, `make jupyter PRESET=cpu-small` looks more ideomatically correct w.r.t. `neuro` terminology.

Please note: simultaneously withi this PR, **[docs](https://github.com/neuromation/platform-web/search?q=TRAINING_MACHINE_TYPE&unscoped_q=TRAINING_MACHINE_TYPE) must be fixed!** 