### PR TITLE
Drop filebrowser authentication

### DIFF
--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -281,7 +281,9 @@ def test_make_run_tensorboard() -> None:
 @pytest.mark.run(order=STEP_KILL)
 @try_except_finally(f"neuro kill {MK_FILEBROWSER_JOB}")
 def test_make_run_filebrowser() -> None:
-    _test_make_run_something_useful("filebrowser", "/login", TIMEOUT_NEURO_RUN_CPU)
+    _test_make_run_something_useful(
+        "filebrowser", "/files/requirements.txt", TIMEOUT_NEURO_RUN_CPU
+    )
 
 
 def _test_make_run_something_useful(target: str, path: str, timeout_run: int) -> None:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -180,7 +180,8 @@ filebrowser:  ### Run a job with File Browser and open UI in the default browser
 		$(HTTP_AUTH) \
 		--browse \
 		--volume $(PROJECT_PATH_STORAGE):/srv:rw \
-		filebrowser/filebrowser
+		filebrowser/filebrowser \
+		--noauth
 
 .PHONY: kill-filebrowser
 kill-filebrowser:  ### Terminate the job with File Browser


### PR DESCRIPTION
Thanks @AlekseySh for pointing out this problem: by default, filebrowser requires credentials `admin:admin`