### PR TITLE
Fix CMD for user's base image

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -67,7 +67,7 @@ setup: ### Setup remote environment
 		--detach \
 		--volume $(PROJECT_PATH_STORAGE):$(PROJECT_PATH_ENV):ro \
 		$(BASE_ENV_NAME) \
-		bash
+		'sleep infinity'
 	$(NEURO) mkdir $(PROJECT_PATH_STORAGE) | true
 	$(NEURO) mkdir $(PROJECT_PATH_STORAGE)/$(CODE_DIR) | true
 	$(NEURO) mkdir $(PROJECT_PATH_STORAGE)/$(DATA_DIR) | true

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -67,7 +67,7 @@ setup: ### Setup remote environment
 		--detach \
 		--volume $(PROJECT_PATH_STORAGE):$(PROJECT_PATH_ENV):ro \
 		$(BASE_ENV_NAME) \
-		'sleep 1h'
+		bash
 	$(NEURO) mkdir $(PROJECT_PATH_STORAGE) | true
 	$(NEURO) mkdir $(PROJECT_PATH_STORAGE)/$(CODE_DIR) | true
 	$(NEURO) mkdir $(PROJECT_PATH_STORAGE)/$(DATA_DIR) | true


### PR DESCRIPTION
Great catch by @atselousov!

Sorry @mariyadavydova for asking you one day to change the command for `make setup` job from `sleep infinity` to `sleep 1h` -- it appeared to be that `docker commit` (which is used in `neuro save`, which is used by `make setup`) sets the `CMD` passed to the container (in this case, `sleep 1h`) to the new image. Then, if one starts a job from this newly created image, and does not specify the command (`neuro run image:my-base-image`), the command will be `sleep 1h`!