### PR TITLE
Fix e2e test cleanup hang

### DIFF
--- a/tests/e2e/cleanup.sh
+++ b/tests/e2e/cleanup.sh
@@ -13,12 +13,12 @@ echo "About to kill $(wc -w <<< $jobs) jobs: $jobs"
 
 echo "-------"
 echo "Before:"
-neuro ps
+neuro -q ps
 echo "-------"
-neuro kill --verbose --trace $jobs
+neuro -v --trace kill $jobs
 echo "-------"
 echo "After:"
-neuro ps
+neuro -q ps
 echo "-------"
 echo "Removing file $JOBS_FILE"
 rm $JOBS_FILE
@@ -31,7 +31,7 @@ dirs=$([ -f $STORAGE_FILE ] && cat $STORAGE_FILE || true)
 echo "About to remove $(wc -w <<< $dirs) directories: $dirs"
 
 echo "-------"
-for d in $dirs; do neuro --verbose --trace rm -r $d; done
+for d in $dirs; do neuro -v --trace rm -r $d; done
 echo "-------"
 echo "Removing file $STORAGE_FILE"
 rm $STORAGE_FILE

--- a/tests/e2e/cleanup.sh
+++ b/tests/e2e/cleanup.sh
@@ -31,13 +31,7 @@ dirs=$([ -f $STORAGE_FILE ] && cat $STORAGE_FILE || true)
 echo "About to remove $(wc -w <<< $dirs) directories: $dirs"
 
 echo "-------"
-echo "Before:"
-#neuro --verbose --trace ls
-echo "-------"
 for d in $dirs; do neuro --verbose --trace rm -r $d; done
-echo "-------"
-echo "After:"
-neuro --verbose --trace ls
 echo "-------"
 echo "Removing file $STORAGE_FILE"
 rm $STORAGE_FILE

--- a/tests/e2e/cleanup.sh
+++ b/tests/e2e/cleanup.sh
@@ -32,7 +32,7 @@ echo "About to remove $(wc -w <<< $dirs) directories: $dirs"
 
 echo "-------"
 echo "Before:"
-neuro --verbose --trace ls
+#neuro --verbose --trace ls
 echo "-------"
 for d in $dirs; do neuro --verbose --trace rm -r $d; done
 echo "-------"

--- a/tests/e2e/cleanup.sh
+++ b/tests/e2e/cleanup.sh
@@ -15,7 +15,7 @@ echo "-------"
 echo "Before:"
 neuro ps
 echo "-------"
-neuro kill $jobs
+neuro kill --verbose --trace $jobs
 echo "-------"
 echo "After:"
 neuro ps

--- a/tests/e2e/cleanup.sh
+++ b/tests/e2e/cleanup.sh
@@ -32,12 +32,12 @@ echo "About to remove $(wc -w <<< $dirs) directories: $dirs"
 
 echo "-------"
 echo "Before:"
-neuro ls
+neuro --verbose --trace ls
 echo "-------"
-for d in $dirs; do neuro rm -r $d; done
+for d in $dirs; do neuro --verbose --trace rm -r $d; done
 echo "-------"
 echo "After:"
-neuro ls
+neuro --verbose --trace ls
 echo "-------"
 echo "Removing file $STORAGE_FILE"
 rm $STORAGE_FILE


### PR DESCRIPTION
Close https://github.com/neuromation/cookiecutter-neuro-project/issues/168

Unfortunately, I haven't understood why `neuro ls` hangs on `dev` builds only -- when I run it locally, everything's fine. 

Example: The output 
```
abc
test-project-07a57d85
test-project-11e6101b
test-project-2a9dc11a
test-project-3172bc9b
test-project-32ea98d7
test-project-34dc3cf5
test-project-466b171f
test-project-59008fe9
test-project-6a013ca5
test-project-71cbfd88
test-project-77e20d13
test-project-92af88de
test-project-a07d7b4a
test-project-b011c804
test-project-b8c20f0d
test-project-e6f127c8
test-project-ed18e3ff
test_project_6ee04879
test_project_76a203c0
test_project_7b22dc52
test_project_7e321888
try-comet-ml
```
is printed until `test_project_7e321888`, then it hangs (so `try-comet-ml` is not printed) -- maybe the problem is there :confused: 

