### PR TITLE
[Makefile] Rename `make ps` -> `make list-jobs`

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -203,6 +203,6 @@ lint:  ### Run static code analysis locally
 
 ##### MISC #####
 
-.PHONY: ps
-ps:  ### List all running and pending jobs
+.PHONY: list-jobs
+list-jobs  ### List all running and pending jobs
 	$(NEURO) ps

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -204,5 +204,5 @@ lint:  ### Run static code analysis locally
 ##### MISC #####
 
 .PHONY: list-jobs
-list-jobs:  ### List all running and pending jobs
-	$(NEURO) ps
+list-jobs:  ### List all running and pending jobs submitted in current project
+	$(NEURO) ps | grep $(PROJECT_POSTFIX) || true

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -213,4 +213,4 @@ lint:  ### Run static code analysis locally
 
 .PHONY: list-jobs
 list-jobs:  ### List all running and pending jobs submitted in current project
-	$(NEURO) ps | grep $(PROJECT_POSTFIX) || true
+	$(NEURO) ps | grep "-$(PROJECT_POSTFIX)" || true

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -204,5 +204,5 @@ lint:  ### Run static code analysis locally
 ##### MISC #####
 
 .PHONY: list-jobs
-list-jobs  ### List all running and pending jobs
+list-jobs:  ### List all running and pending jobs
 	$(NEURO) ps


### PR DESCRIPTION
for a regular user, `ps` means nothing. Moreover, `make ps` makes no sense if it runs only `neuro ps`. When renamed, it makes more sense.