### PR TITLE
[tests] Minor: simplify running tests against existing projects

### DIFF
--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -42,7 +42,7 @@ TIMEOUT_NEURO_KILL = 20
 # all variables prefixed "MK_" are taken in Makefile (without prefix)
 # Project name is defined in cookiecutter.yaml, from `project_name`
 UNIQUE_PROJECT_NAME = f"Test Project {unique_label()}"
-EXISTING_PROJECT_SLUG = os.environ.get("EXISTING_PROJECT_SLUG")
+EXISTING_PROJECT_SLUG = os.environ.get("PROJECT")
 MK_PROJECT_SLUG = EXISTING_PROJECT_SLUG or UNIQUE_PROJECT_NAME.lower().replace(" ", "-")
 
 MK_CODE_DIR = "modules"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -94,7 +94,9 @@ def change_directory_to_temp() -> t.Iterator[None]:
 
 @pytest.fixture(scope="session", autouse=True)
 def cookiecutter_setup(change_directory_to_temp: None) -> t.Iterator[None]:
-    if not EXISTING_PROJECT_SLUG:
+    if EXISTING_PROJECT_SLUG:
+        log_msg(f"Running tests for existing project: {EXISTING_PROJECT_SLUG}")
+    else:
         run(
             f"cookiecutter --no-input --config-file={LOCAL_PROJECT_CONFIG_PATH} "
             f'{LOCAL_ROOT_PATH} project_name="{UNIQUE_PROJECT_NAME}"',
@@ -102,6 +104,7 @@ def cookiecutter_setup(change_directory_to_temp: None) -> t.Iterator[None]:
             verbose=False,
         )
     with inside_dir(MK_PROJECT_SLUG):
+        log_msg(f"Working inside test project: {Path().absolute()}")
         yield
 
 


### PR DESCRIPTION
1. Make env var shorter so that it's easier to remember (when using this functionality, I always need to go to `configuration.py` to remember `EXISTING_PROJECT_SLUG`)
2. add a bit logging info -- just for clarity