### PR TITLE
Fix flaky test

### DIFF
--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -161,8 +161,8 @@ def _get_pattern_status_running() -> str:
     return r"Status:[^\n]+running"
 
 
-def _get_pattern_status_succeeded() -> str:
-    return r"Status:[^\n]+succeeded"
+def _get_pattern_status_succeeded_or_running() -> str:
+    return r"Status:[^\n]+(succeeded|running)"
 
 
 def _get_pattern_pip_installing(pip: str) -> str:

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -40,7 +40,7 @@ from tests.e2e.configuration import (
     TIMEOUT_NEURO_RUN_CPU,
     _get_pattern_pip_installing,
     _get_pattern_status_running,
-    _get_pattern_status_succeeded,
+    _get_pattern_status_succeeded_or_running,
     _pattern_copy_file_finished,
     _pattern_copy_file_started,
     _pattern_upload_dir,
@@ -319,7 +319,7 @@ def test_make_download_noteboooks() -> None:
 @pytest.mark.run(order=STEP_RUN)
 def test_make_train_default_command(env_neuro_run_timeout: int) -> None:
     expect_patterns = [
-        _get_pattern_status_succeeded(),
+        _get_pattern_status_succeeded_or_running(),
         "Replace this placeholder with a training script execution",
     ]
     _run_make_train_test(env_neuro_run_timeout, expect_patterns=expect_patterns)


### PR DESCRIPTION
test for `make train` flakes: we await status `succeeded`, but sometimes `neuro` sees `running` instead:
https://circleci.com/gh/neuromation/cookiecutter-neuro-project/1209