### PR TITLE
[Makefile] Google Cloud SDK integration: full automation

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -54,7 +54,7 @@ LOCAL_PORT?=2211
 GCP_SECRET_FILE?=neuro-job-key.json
 GCP_PROJECT_ID?=
 GCP_SERVICE_ACCOUNT_NAME?=
-GCP_BUCKET_NAME?=
+GCP_BUCKET?=
 
 GCP_SECRET_PATH_LOCAL=${CONFIG_DIR}/${GCP_SECRET_FILE}
 GCP_SECRET_PATH_ENV=${PROJECT_PATH_ENV}/${GCP_SECRET_PATH_LOCAL}
@@ -197,41 +197,51 @@ gcloud-setup:   ### Set up Google Cloud environment to work with Neuro Platform
 	@echo "--"
 	@test "${GCP_PROJECT_ID}" || { echo "ERROR: env var 'GCP_PROJECT_ID' is not set"; false; }
 	@test "${GCP_SERVICE_ACCOUNT_NAME}" || { echo "ERROR: env var 'GCP_SERVICE_ACCOUNT_NAME' is not set"; false; }
-	@test "${GCP_BUCKET_NAME}" || { echo "ERROR: env var 'GCP_BUCKET_NAME' is not set"; false; }
+	@test "${GCP_BUCKET}" || { echo "ERROR: env var 'GCP_BUCKET' is not set"; false; }
 	# Checking that Google Cloud SDK is installed...
 	@gcloud --version >/dev/null && gsutil --version >/dev/null \
 		&& echo "OK" \
-		|| { echo "Please install Google Cloud SDK (see https://cloud.google.com/sdk/install)"; false; }
+		|| { echo 'Please install Google Cloud SDK (see https://cloud.google.com/sdk/install)'; \
+			false; }
 	# Checking that Google Project GCP_PROJECT_ID="${GCP_PROJECT_ID}" exists...
 	@gcloud projects describe ${GCP_PROJECT_ID} >/dev/null \
 		&& echo "OK" \
-		|| { echo -e "Google project GCP_PROJECT_ID=${GCP_PROJECT_ID} does not exist.\nPlease run 'gcloud projects create ${GCP_PROJECT_ID}'"; false; }
-	# Checking that gcloud is set up to use Google Project GCP_PROJECT_ID"${GCP_PROJECT_ID}" by default...
+		|| { echo "Google project GCP_PROJECT_ID='${GCP_PROJECT_ID}' does not exist or not enough permissions."; \
+			echo "Please run: 'gcloud projects create ${GCP_PROJECT_ID}'"; \
+			false; }
+	# Checking that gcloud is set up to use Google Project GCP_PROJECT_ID="${GCP_PROJECT_ID}" by default...
 	@[ `gcloud config list --format 'value(core.project)'` == ${GCP_PROJECT_ID} ] \
 		&& echo "OK" \
-		|| { echo -e "Google project GCP_PROJECT_ID=${GCP_PROJECT_ID} is not default.\nPlease run 'gcloud config set project ${GCP_PROJECT_ID}'"; false; }
+		|| { echo -e 'Google project GCP_PROJECT_ID=${GCP_PROJECT_ID} is not default.'; \
+		 echo 'Please run "gcloud config set project ${GCP_PROJECT_ID}"'; \
+		 false; }
 	# Checking that Google Service Account GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT}" exists...
 	@gcloud iam service-accounts describe ${GCP_SERVICE_ACCOUNT} >/dev/null \
 		&& echo "OK" \
-		|| { echo -e "Could not find Google service account GCP_SERVICE_ACCOUNT=${GCP_SERVICE_ACCOUNT}.\nPlease run 'gcloud iam service-accounts create ${GCP_SERVICE_ACCOUNT} --description \"Neuro Platform Job Service Account for Google Project '${GCP_PROJECT_ID}'\" --display-name \"Neuro Platform Job for '${GCP_PROJECT_ID}'\"'"; false; }
-	# Checking that Bucket GCP_BUCKET_NAME="${GCP_BUCKET_NAME}" exists...
-	@gsutil ls gs://${GCP_BUCKET_NAME}/ >/dev/null \
+		|| { echo "Could not find Google service account GCP_SERVICE_ACCOUNT='${GCP_SERVICE_ACCOUNT}'."; \
+			echo "Please run 'gcloud iam service-accounts create ${GCP_SERVICE_ACCOUNT} --description \"Neuro Platform Job Service Account\" --display-name \"Neuro Platform Job\" '"; \
+			false; }
+	# Checking that Bucket GCP_BUCKET="${GCP_BUCKET}" exists...
+	@gsutil ls gs://${GCP_BUCKET}/ >/dev/null \
 		&& echo "OK" \
-		|| { echo -e "Bucket GCP_BUCKET_NAME=${GCP_BUCKET_NAME} does not exist.\nPlease run 'gsutil mb gs://${GCP_BUCKET_NAME}'"; false; }
-	# Checking that Service Account GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT}" is an 'objectAdmin' of Bucket GCP_BUCKET_NAME="${GCP_BUCKET_NAME}"...
-	@gsutil iam get gs://${GCP_BUCKET_NAME} | jq --exit-status '.bindings | map(select(.role == "roles/storage.objectAdmin")) | .[].members[] | contains("${GCP_SERVICE_ACCOUNT}")' >/dev/null \
+		|| { echo "Bucket GCP_BUCKET='${GCP_BUCKET}' does not exist."; \
+			echo "Please run 'gsutil mb gs://${GCP_BUCKET}'"; \
+			false; }
+	# Checking that Service Account GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT}" is an 'objectAdmin' of Bucket GCP_BUCKET="${GCP_BUCKET}"...
+	@gsutil iam get gs://${GCP_BUCKET} | jq --exit-status '.bindings | map(select(.role == "roles/storage.objectAdmin")) | .[].members[] | contains("${GCP_SERVICE_ACCOUNT}")' >/dev/null \
 		&& echo "OK" \
-		|| { echo -e "Service Account GCP_SERVICE_ACCOUNT=${GCP_SERVICE_ACCOUNT} cannot manage Bucket GCP_BUCKET_NAME=${GCP_BUCKET_NAME}.\nPlease run 'gsutil iam ch serviceAccount:${GCP_SERVICE_ACCOUNT}:roles/storage.objectAdmin gs://r${GCP_BUCKET_NAME}'"; false; }
+		|| { echo "Service Account GCP_SERVICE_ACCOUNT='${GCP_SERVICE_ACCOUNT}' cannot manage Bucket GCP_BUCKET='${GCP_BUCKET}'."; \
+			echo "Please run 'gsutil iam ch serviceAccount:${GCP_SERVICE_ACCOUNT}:roles/storage.objectAdmin gs://${GCP_BUCKET}'"; \
+			false; }
 	# Downloading authentication file for Service Account GCP_SERVICE_ACCOUNT=${GCP_SERVICE_ACCOUNT} to local directory "./${CONFIG_DIR}"...
-	@[ ! -f ${GCP_SECRET_PATH_LOCAL} ] \
+	@[ ! -f "${GCP_SECRET_PATH_LOCAL}" ] \
 		&& { gcloud iam service-accounts keys create ./${GCP_SECRET_PATH_LOCAL} --iam-account ${GCP_SERVICE_ACCOUNT} \
 			|| echo "Please note: maximum 9 keys are allowed (see 'make gcloud-list-keys' for cleanup instructions)"; } \
-		|| echo "WARNING: File ./${GCP_SECRET_PATH_LOCAL} already exists, skipping"
+		|| echo "WARNING: File './${GCP_SECRET_PATH_LOCAL}' already exists, skipping"
 	# Setting restricted permissions on the secret file "${GCP_SECRET_PATH_LOCAL}"...
 	@chmod 600 ./${GCP_SECRET_PATH_LOCAL} \
 		&& echo "OK"
 	@echo "Google Cloud environment successfully configured!"
-	@echo 'Please run "export $$(make gcloud-env)" to set up environment variables locally (will be already set up in the development job)'
 
 .PHONY: _check_gcloud_setup
 _check_gcloud_setup:
@@ -239,7 +249,7 @@ _check_gcloud_setup:
 
 .PHONY: _gcloud_require_bucket
 _gcloud_require_bucket:
-	@test $${GCP_BUCKET_NAME} || { echo 'Please run "export $$(make gcloud-env)" first'; false; }
+	@test $${GCP_BUCKET} || { echo 'Please run "export $$(make gcloud-env)" first'; false; }
 
 .PHONY: gcloud-list-keys
 gcloud-list-keys:   ### List keys used by Google Service Account ""${GCP_SERVICE_ACCOUNT}""
@@ -257,19 +267,19 @@ gcloud-env:  ### Print environment variables that store Google Cloud configurati
 ifdef GCP_SERVICE_ACCOUNT_NAME
 	@echo GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT}"
 endif
-	@echo GCP_BUCKET_NAME="${GCP_BUCKET_NAME}"
+	@echo GCP_BUCKET="${GCP_BUCKET}"
 
 .PHONY:  gcloud-ls
 gcloud-ls: _check_gcloud_setup _gcloud_require_bucket  ### TBD
-	gsutil ls $${GCP_BUCKET_NAME}
+	gsutil ls $${GCP_BUCKET}
 
 .PHONY:  gcloud-upload-data
 gcloud-upload-data: _check_gcloud_setup _gcloud_require_bucket  ### TBD
-	gsutil -m cp -r ${DATA_DIR}/ $${GCP_BUCKET_NAME}
+	gsutil -m cp -r ${DATA_DIR}/ $${GCP_BUCKET}
 
 .PHONY:  gcloud-download-data
 gcloud-download-data: _check_gcloud_setup _gcloud_require_bucket  ### TBD
-	gsutil -m cp -r $${GCP_BUCKET_NAME}/${DATA_DIR} .
+	gsutil -m cp -r $${GCP_BUCKET}/${DATA_DIR} .
 
 
 ##### WandB Integration #####

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -52,9 +52,13 @@ LOCAL_PORT?=2211
 
 # Google Cloud integration settings:
 GCP_SECRET_FILE?=neuro-job-key.json
+GCP_PROJECT_ID?=
+GCP_SERVICE_ACCOUNT_NAME?=
+GCP_BUCKET_NAME?=
 
 GCP_SECRET_PATH_LOCAL=${CONFIG_DIR}/${GCP_SECRET_FILE}
 GCP_SECRET_PATH_ENV=${PROJECT_PATH_ENV}/${GCP_SECRET_PATH_LOCAL}
+GCP_SERVICE_ACCOUNT=${GCP_SERVICE_ACCOUNT_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com
 
 # Weights and Biases integration settings:
 WANDB_SECRET_FILE?=wandb-token.txt
@@ -73,7 +77,8 @@ NEURO?=neuro
 ifneq ($(wildcard ${GCP_SECRET_PATH_LOCAL}),)
 	OPTION_GCP_CREDENTIALS=\
 		--env GOOGLE_APPLICATION_CREDENTIALS=${GCP_SECRET_PATH_ENV} \
-		--env GCP_SERVICE_ACCOUNT_KEY_PATH=${GCP_SECRET_PATH_ENV}
+		--env GCP_SERVICE_ACCOUNT_KEY_PATH=${GCP_SECRET_PATH_ENV} \
+		$(foreach var,$(shell make gcloud-env), --env $(var))
 else
 	OPTION_GCP_CREDENTIALS=
 endif
@@ -176,10 +181,96 @@ clean-all: clean-code clean-data clean-config clean-notebooks  ### Delete code, 
 gcloud-check-auth:  ### Check if the file containing Google Cloud service account key exists
 	@echo "Using variable: GCP_SECRET_FILE='${GCP_SECRET_FILE}'"
 	@test "${OPTION_GCP_CREDENTIALS}" \
-		&& echo "Google Cloud will be authenticated via service account key file: '$${PWD}/${GCP_SECRET_PATH_LOCAL}'" \
+		&& { echo "Google Cloud will be authenticated via service account key file: '$${PWD}/${GCP_SECRET_PATH_LOCAL}'"; \
+			 echo "--"; \
+			 make --silent gcloud-env; \
+			 echo "--"; } \
 		|| { echo "ERROR: Not found Google Cloud service account key file: '$${PWD}/${GCP_SECRET_PATH_LOCAL}'"; \
 			echo "Please save the key file named GCP_SECRET_FILE='${GCP_SECRET_FILE}' to './${CONFIG_DIR}/'"; \
 			false; }
+
+.PHONY: gcloud-setup
+gcloud-setup:   ### Set up Google Cloud environment to work with Neuro Platform
+	@echo "Google Cloud configuration:"
+	@echo "--"
+	@make --silent gcloud-env
+	@echo "--"
+	@test "${GCP_PROJECT_ID}" || { echo "ERROR: env var 'GCP_PROJECT_ID' is not set"; false; }
+	@test "${GCP_SERVICE_ACCOUNT_NAME}" || { echo "ERROR: env var 'GCP_SERVICE_ACCOUNT_NAME' is not set"; false; }
+	@test "${GCP_BUCKET_NAME}" || { echo "ERROR: env var 'GCP_BUCKET_NAME' is not set"; false; }
+	# Checking that Google Cloud SDK is installed...
+	@gcloud --version >/dev/null && gsutil --version >/dev/null \
+		&& echo "OK" \
+		|| { echo "Please install Google Cloud SDK (see https://cloud.google.com/sdk/install)"; false; }
+	# Checking that Google Project GCP_PROJECT_ID="${GCP_PROJECT_ID}" exists...
+	@gcloud projects describe ${GCP_PROJECT_ID} >/dev/null \
+		&& echo "OK" \
+		|| { echo -e "Google project GCP_PROJECT_ID=${GCP_PROJECT_ID} does not exist.\nPlease run 'gcloud projects create ${GCP_PROJECT_ID}'"; false; }
+	# Checking that gcloud is set up to use Google Project GCP_PROJECT_ID"${GCP_PROJECT_ID}" by default...
+	@[ `gcloud config list --format 'value(core.project)'` == ${GCP_PROJECT_ID} ] \
+		&& echo "OK" \
+		|| { echo -e "Google project GCP_PROJECT_ID=${GCP_PROJECT_ID} is not default.\nPlease run 'gcloud config set project ${GCP_PROJECT_ID}'"; false; }
+	# Checking that Google Service Account GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT}" exists...
+	@gcloud iam service-accounts describe ${GCP_SERVICE_ACCOUNT} >/dev/null \
+		&& echo "OK" \
+		|| { echo -e "Could not find Google service account GCP_SERVICE_ACCOUNT=${GCP_SERVICE_ACCOUNT}.\nPlease run 'gcloud iam service-accounts create ${GCP_SERVICE_ACCOUNT} --description \"Neuro Platform Job Service Account for Google Project '${GCP_PROJECT_ID}'\" --display-name \"Neuro Platform Job for '${GCP_PROJECT_ID}'\"'"; false; }
+	# Checking that Bucket GCP_BUCKET_NAME="${GCP_BUCKET_NAME}" exists...
+	@gsutil ls gs://${GCP_BUCKET_NAME}/ >/dev/null \
+		&& echo "OK" \
+		|| { echo -e "Bucket GCP_BUCKET_NAME=${GCP_BUCKET_NAME} does not exist.\nPlease run 'gsutil mb gs://${GCP_BUCKET_NAME}'"; false; }
+	# Checking that Service Account GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT}" is an 'objectAdmin' of Bucket GCP_BUCKET_NAME="${GCP_BUCKET_NAME}"...
+	@gsutil iam get gs://${GCP_BUCKET_NAME} | jq --exit-status '.bindings | map(select(.role == "roles/storage.objectAdmin")) | .[].members[] | contains("${GCP_SERVICE_ACCOUNT}")' >/dev/null \
+		&& echo "OK" \
+		|| { echo -e "Service Account GCP_SERVICE_ACCOUNT=${GCP_SERVICE_ACCOUNT} cannot manage Bucket GCP_BUCKET_NAME=${GCP_BUCKET_NAME}.\nPlease run 'gsutil iam ch serviceAccount:${GCP_SERVICE_ACCOUNT}:roles/storage.objectAdmin gs://r${GCP_BUCKET_NAME}'"; false; }
+	# Downloading authentication file for Service Account GCP_SERVICE_ACCOUNT=${GCP_SERVICE_ACCOUNT} to local directory "./${CONFIG_DIR}"...
+	@[ ! -f ${GCP_SECRET_PATH_LOCAL} ] \
+		&& { gcloud iam service-accounts keys create ./${GCP_SECRET_PATH_LOCAL} --iam-account ${GCP_SERVICE_ACCOUNT} \
+			|| echo "Please note: maximum 9 keys are allowed (see 'make gcloud-list-keys' for cleanup instructions)"; } \
+		|| echo "WARNING: File ./${GCP_SECRET_PATH_LOCAL} already exists, skipping"
+	# Setting restricted permissions on the secret file "${GCP_SECRET_PATH_LOCAL}"...
+	@chmod 600 ./${GCP_SECRET_PATH_LOCAL} \
+		&& echo "OK"
+	@echo "Google Cloud environment successfully configured!"
+	@echo 'Please run "export $$(make gcloud-env)" to set up environment variables locally (will be already set up in the development job)'
+
+.PHONY: _check_gcloud_setup
+_check_gcloud_setup:
+	@test ${OPTION_GCP_CREDENTIALS} || { echo "Please run 'make gcloud-setup' first"; false; }
+
+.PHONY: _gcloud_require_bucket
+_gcloud_require_bucket:
+	@test $${GCP_BUCKET_NAME} || { echo 'Please run "export $$(make gcloud-env)" first'; false; }
+
+.PHONY: gcloud-list-keys
+gcloud-list-keys:   ### List keys used by Google Service Account ""${GCP_SERVICE_ACCOUNT}""
+	gcloud iam service-accounts keys list --iam-account ${GCP_SERVICE_ACCOUNT}
+	@echo "Run 'gcloud iam service-accounts keys delete --iam-account ${GCP_SERVICE_ACCOUNT} {KEY_ID}' to delete unnecessary keys."
+
+.PHONY: gcloud-clean-auth
+gcloud-clean-auth:   ### Removes secret file used to authenticate Google Cloud SDK
+	rm ${GCP_SECRET_PATH_LOCAL}
+
+.PHONY:  gcloud-env
+gcloud-env:  ### Print environment variables that store Google Cloud configuration (run "export `make gcloud-env`" to apply)
+	@echo GCP_PROJECT_ID="${GCP_PROJECT_ID}"
+	@echo GCP_SERVICE_ACCOUNT_NAME="${GCP_SERVICE_ACCOUNT_NAME}"
+ifdef GCP_SERVICE_ACCOUNT_NAME
+	@echo GCP_SERVICE_ACCOUNT="${GCP_SERVICE_ACCOUNT}"
+endif
+	@echo GCP_BUCKET_NAME="${GCP_BUCKET_NAME}"
+
+.PHONY:  gcloud-ls
+gcloud-ls: _check_gcloud_setup _gcloud_require_bucket  ### TBD
+	gsutil ls $${GCP_BUCKET_NAME}
+
+.PHONY:  gcloud-upload-data
+gcloud-upload-data: _check_gcloud_setup _gcloud_require_bucket  ### TBD
+	gsutil -m cp -r ${DATA_DIR}/ $${GCP_BUCKET_NAME}
+
+.PHONY:  gcloud-download-data
+gcloud-download-data: _check_gcloud_setup _gcloud_require_bucket  ### TBD
+	gsutil -m cp -r $${GCP_BUCKET_NAME}/${DATA_DIR} .
+
 
 ##### WandB Integration #####
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -107,6 +107,51 @@ Hello World
 
 Also, environment variable `GOOGLE_APPLICATION_CREDENTIALS` is set up for these jobs, so that you an access your data on Google Cloud Storage via Python API (see example in [Google Cloud Storage documentation](https://cloud.google.com/storage/docs/reference/libraries)).
 
+### Uploading to the Job from Google Cloud
+
+Google Cloud SDK is pre-installed on all jobs produced from the Base Image.
+Neuro Project Template provides a fast way to authenticate Google Cloud SDK to work with Google Service Account 
+(see instructions on setting up your Google Project and Google Service Account and creating the secret key for
+this Service Account in [documentation](https://neu.ro/docs/google_cloud_storage)).
+
+Once you have created the key file via command `gcloud iam service-accounts keys create key.json ...`,
+put this file to the local config directory `./config/` and set appropriate permissions on it:
+
+```
+chmod 600 ./config/key.json
+```
+
+Then, inform Neuro about this file:
+```
+export GCP_SECRET_FILE=key.json
+```
+Alternatively, set this value directly in `Makefile`.
+
+Check that Neuro has found and this file:
+```
+$ make gcloud-check-auth
+[+] Found Google Cloud service account authentication file: 'config/key.json'
+```
+
+Great! Now, if you run a development job, Neuro will authenticate Google Cloud SDK via your secret file:
+```
+$ make develop
+...
+Activated service account credentials for: [project-id@service-account-name.iam.gserviceaccount.com]
+[+] Google Cloud SDK configured for job develop-name-of-the-project
+```
+
+Then, you can connect to the development job and use `gsutil` or `gcloud` there!
+```
+$ make connect-develop
+...
+root@job-56e9b297-5034-4492-ba1a-2284b8dcd613:/# gsutil cat gs://my-neuro-bucket-42/hello.txt
+Hello World
+```
+
+Also, development job has environment variable `GOOGLE_APPLICATION_CREDENTIALS` set up, which means that you an access your data on Google Cloud Storage via Python API (see usage example on [Google Cloud Storage documentation](https://cloud.google.com/storage/docs/reference/libraries)).
+
+
 ## Customization
 
 Several variables in `Makefile` are intended to be modified according to the project specifics. 


### PR DESCRIPTION
Implements instructions from https://github.com/neuromation/platform-web/pull/119

The main idea of `make gcloud-setup` is not to perform any change via `gcloud` or `gsutil`, but only to check the configuration automatically and to suggest user command to fix. Once it succeeds, the secret file and env var configuration files are stored to the `./config/` directory. Then, once the job started, if the secret file exists, `gcloud auth` will be called.

Idea for future: perform encryption of secret files stored in `./config` so that shared jobs don't reveal secret tokens.

TODO: Some tests will be implemented once the Makefile is reviewed.