### PR TITLE
[Template] Add dependencies mypy+isort+black+flake

### DIFF
--- a/{{cookiecutter.project_slug}}/requirements.txt
+++ b/{{cookiecutter.project_slug}}/requirements.txt
@@ -1,1 +1,4 @@
-tqdm==4.32.1
+flake8
+mypy
+isort
+black


### PR DESCRIPTION
Closes https://github.com/neuromation/cookiecutter-neuro-project/issues/283

Before, `tqdm` in `requirements.txt` was just an example. 
1. We'll install it to the base image
2. No tests rely on it.

Question: Should we pre-install these dependencies also to the base image in order to shorten `make setup` time?