### PR TITLE
[tests] Integrate instafail

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,5 +10,5 @@ pytest==5.1.2
 pytest-ordering==0.6
 pytest-cookies==0.4.0
 pytest-aiohttp==0.3.0
-pytest-rerunfailures==7.0
 pytest-logger==0.5.1
+pytest-instafail==0.4.1.post0

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -448,6 +448,7 @@ def test_make_train_default_command(env_neuro_run_timeout: int) -> None:
         _get_pattern_status_succeeded_or_running(),
         "Your training script here",
     ]
+    raise Exception("this is message 1")
     _run_make_train_test(env_neuro_run_timeout, expect_patterns=expect_patterns)
 
 
@@ -455,6 +456,7 @@ def test_make_train_default_command(env_neuro_run_timeout: int) -> None:
 def test_make_train_custom_command(
     monkeypatch: Any, env_neuro_run_timeout: int, env_py_command_check_gpu: str
 ) -> None:
+    raise Exception("this is message 2")
     cmd = env_py_command_check_gpu
     cmd = cmd.replace('"', r"\"")
     cmd = f"'python -W ignore -c \"{cmd}\"'"
@@ -515,6 +517,7 @@ def _test_make_run_filebrowser() -> None:
 def _test_make_run_something_useful(target: str, path: str, timeout_run: int) -> None:
     # Can't test web UI with HTTP auth
     make_cmd = f"make {target}"
+    raise Exception("this is message 3")
     with measure_time(make_cmd):
         out = run(
             make_cmd,


### PR DESCRIPTION
Integrate [pytest-instafail](https://github.com/pytest-dev/pytest-instafail): show failures and errors instantly instead of waiting until the end of test session