### PR TITLE
[Makefile] Use latest base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ cook:
 
 .PHONY: version
 version:
-	@grep -Po "BASE_ENV_VERSION=(\Kv.*)" \{\{cookiecutter.project_slug\}\}/Makefile || echo "v?.?"
+	@grep -Po "^VERSION=(\K.+)" \{\{cookiecutter.project_slug\}\}/Makefile || echo "v?.?"
 
 .PHONY: lint
 lint:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -1,5 +1,7 @@
 ##### PATHS #####
 
+VERSION=v1.2
+
 DATA_DIR?=data
 CONFIG_DIR?=config
 CODE_DIR?={{cookiecutter.code_directory}}
@@ -25,9 +27,8 @@ FILEBROWSER_JOB?=filebrowser-$(PROJECT_POSTFIX)
 
 ##### ENVIRONMENTS #####
 
-BASE_ENV_VERSION=v1.2
-BASE_ENV_NAME?=neuromation/base:$(BASE_ENV_VERSION)
-CUSTOM_ENV_NAME?=image:neuromation-$(PROJECT_POSTFIX):$(BASE_ENV_VERSION)
+BASE_ENV_NAME?=neuromation/base:latest
+CUSTOM_ENV_NAME?=image:neuromation-$(PROJECT_POSTFIX):$(VERSION)
 
 ##### VARIABLES YOU MAY WANT TO MODIFY #####
 


### PR DESCRIPTION
See https://github.com/neuromation/neuro-base-environment/issues/81

No need to support (keep them pre-pulled on nodes) multiple tags:
1. we'll keep backward compatibility of the base image
2. we'll update `latest` image manually, only stable image -- not on every change
3. base image is used only in `make setup`: so updated `latest` base image won't affect existing user's custom base images.