### PR TITLE
[tests] Stabilize tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
           name: run unit tests
           command: |
             . venv/bin/activate
+            make test_doctest
             make test_unit
       - run:
           no_output_timeout: 20m

--- a/Makefile
+++ b/Makefile
@@ -26,18 +26,20 @@ format:
 	isort -rc $(LINTER_DIRS)
 	black $(LINTER_DIRS)
 
+
+.PHONY: test_doctest
+test_doctest:
+	python -m doctest tests/e2e/conftest.py
+	python -m doctest tests/e2e/helpers/runners.py
+	python -m doctest tests/e2e/helpers/utils.py
+	@echo -e "OK\n"
+
 .PHONY: test_unit
 test_unit:
 	pytest -v -s tests/unit
 	@echo -e "OK\n"
-	# Test cookiecutter manually:
 	cookiecutter --no-input --config-file ./tests/cookiecutter.yaml --output-dir $(TMP_DIR) .
 	stat $(TMP_DIR)/test-project
-	@echo -e "OK\n"
-	# Run doctests:
-	python -m doctest tests/e2e/conftest.py
-	python -m doctest tests/e2e/helpers/runners.py
-	python -m doctest tests/e2e/helpers/utils.py
 	@echo -e "OK\n"
 
 .PHONY: test_e2e_dev

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 LINTER_DIRS := tests
 NEURO_COMMAND := "neuro --verbose --show-traceback"
+TMP_DIR := $(shell mktemp -d)
 
 .PHONY: init
 init:
@@ -28,9 +29,16 @@ format:
 .PHONY: test_unit
 test_unit:
 	pytest -v -s tests/unit
-	cookiecutter --no-input --config-file ./tests/cookiecutter.yaml --output-dir .. .
-	stat ../test-project
+	@echo -e "OK\n"
+	# Test cookiecutter manually:
+	cookiecutter --no-input --config-file ./tests/cookiecutter.yaml --output-dir $(TMP_DIR) .
+	stat $(TMP_DIR)/test-project
+	@echo -e "OK\n"
+	# Run doctests:
 	python -m doctest tests/e2e/conftest.py
+	python -m doctest tests/e2e/helpers/runners.py
+	python -m doctest tests/e2e/helpers/utils.py
+	@echo -e "OK\n"
 
 .PHONY: test_e2e_dev
 test_e2e_dev:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ mypy==0.720
 isort==4.3.21
 black==19.3b0
 cookiecutter==1.6.0
-fernet==1.0.1
+cryptography==2.8
 
 pexpect==4.7.0
 pytest==5.1.2

--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -170,6 +170,7 @@ DEFAULT_NEURO_ERROR_PATTERNS = (
 )
 DEFAULT_MAKE_ERROR_PATTERNS = ("Makefile:.+", "recipe for target .+ failed.+")
 DEFAULT_ERROR_PATTERNS = DEFAULT_MAKE_ERROR_PATTERNS + DEFAULT_NEURO_ERROR_PATTERNS
+DEFAULT_ERROR_SUBSTRINGS_JOB_RUN = ["stale NFS file handle"]
 
 
 def mk_train_job(run: str = MK_RUN_DEFAULT) -> str:

--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -90,8 +90,8 @@ MK_PROJECT_DIRS = {
 MK_PROJECT_FILES = [PROJECT_PIP_FILE_NAME, PROJECT_APT_FILE_NAME, "setup.cfg"]
 
 # note: apt package 'expect' requires user input during installation
-PACKAGES_APT_CUSTOM = ["expect", "figlet"]
-PACKAGES_PIP_CUSTOM = ["aiohttp==3.6", "aiohttp_security", "neuromation==19.9.10"]
+PACKAGES_APT_CUSTOM = ["figlet"]
+PACKAGES_PIP_CUSTOM = ["neuromation"]
 GCP_KEY_FILE = "gcp-key.json"
 AWS_KEY_FILE = "aws-credentials.txt"
 WANDB_KEY_FILE = "wandb-fake-key.txt"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -269,32 +269,31 @@ def neuro_login(
 
 
 @pytest.fixture()
-def monkeypatch_setenv(monkeypatch: t.Any) -> t.Callable[[str, str], None]:
-    def _f(key: str, val: str) -> None:
-        log_msg(f"Setting env var: {key}={val}")
-        monkeypatch.setenv("PRESET", "cpu-small")
-
-    return _f
+def env_var_preset_cpu_small(monkeypatch: t.Any) -> None:
+    key, val = "PRESET", "cpu-small"
+    log_msg(f"Setting env var: {key}={val}")
+    monkeypatch.setenv(key, val)
 
 
 @pytest.fixture()
-def env_var_preset_cpu_small(monkeypatch_setenv: t.Any) -> None:
-    monkeypatch_setenv("PRESET", "cpu-small")
+def env_var_no_http_auth(monkeypatch: t.Any) -> None:
+    key, val = "HTTP_AUTH", "--no-http-auth"
+    log_msg(f"Setting env var: {key}={val}")
+    monkeypatch.setenv(key, val)
 
 
 @pytest.fixture()
-def env_var_no_http_auth(monkeypatch_setenv: t.Any) -> None:
-    monkeypatch_setenv("HTTP_AUTH", "--no-http-auth")
+def env_var_train_stream_logs(monkeypatch: t.Any) -> None:
+    key, val = "TRAIN_STREAM_LOGS", "yes"
+    log_msg(f"Setting env var: {key}={val}")
+    monkeypatch.setenv(key, val)
 
 
 @pytest.fixture()
-def env_var_train_stream_logs(monkeypatch_setenv: t.Any) -> None:
-    monkeypatch_setenv("TRAIN_STREAM_LOGS", "yes")
-
-
-@pytest.fixture()
-def env_var_train_no_stream_logs(monkeypatch_setenv: t.Any) -> None:
-    monkeypatch_setenv("TRAIN_STREAM_LOGS", "no")
+def env_var_train_no_stream_logs(monkeypatch: t.Any) -> None:
+    key, val = "TRAIN_STREAM_LOGS", "no"
+    log_msg(f"Setting env var: {key}={val}")
+    monkeypatch.setenv(key, val)
 
 
 def _decrypt_file(file_enc: Path, output: Path) -> None:
@@ -326,8 +325,10 @@ def _decrypt_key(key_name: str) -> t.Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def env_var_gcp_secret_file(monkeypatch_setenv: t.Any) -> None:
-    monkeypatch_setenv("GCP_SECRET_FILE", GCP_KEY_FILE)
+def env_var_gcp_secret_file(monkeypatch: t.Any) -> None:
+    key, val = "GCP_SECRET_FILE", GCP_KEY_FILE
+    log_msg(f"Setting env var: {key}={val}")
+    monkeypatch.setenv(key, val)
 
 
 @pytest.fixture()
@@ -336,8 +337,10 @@ def decrypt_gcp_key() -> t.Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def env_var_aws_secret_file(monkeypatch_setenv: t.Any) -> None:
-    monkeypatch_setenv("AWS_SECRET_FILE", AWS_KEY_FILE)
+def env_var_aws_secret_file(monkeypatch: t.Any) -> None:
+    key, val = "AWS_SECRET_FILE", AWS_KEY_FILE
+    log_msg(f"Setting env var: {key}={val}")
+    monkeypatch.setenv(key, val)
 
 
 @pytest.fixture()
@@ -346,8 +349,10 @@ def decrypt_aws_key() -> t.Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def env_var_wandb_secret_file(monkeypatch_setenv: t.Any) -> None:
-    monkeypatch_setenv("WANDB_SECRET_FILE", WANDB_KEY_FILE)
+def env_var_wandb_secret_file(monkeypatch: t.Any) -> None:
+    key, val = "WANDB_SECRET_FILE", WANDB_KEY_FILE
+    log_msg(f"Setting env var: {key}={val}")
+    monkeypatch.setenv(key, val)
 
 
 @pytest.fixture()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -248,7 +248,7 @@ def neuro_project_id() -> str:
 @pytest.fixture(scope="session", autouse=True)
 def pip_install_neuromation(generate_empty_project: None) -> None:
     if not EXISTING_PROJECT_SLUG:
-        run("pip install -U neuromation", verbose=False, skip_error_patterns_check=True)
+        run("pip install -U neuromation", verbose=False, check_default_errors=False)
     log_msg(f"Using: {run('neuro --version', verbose=False)}")
 
 
@@ -269,23 +269,32 @@ def neuro_login(
 
 
 @pytest.fixture()
-def env_var_preset_cpu_small(monkeypatch: t.Any) -> None:
-    monkeypatch.setenv("PRESET", "cpu-small")
+def monkeypatch_setenv(monkeypatch: t.Any) -> t.Callable[[str, str], None]:
+    def _f(key: str, val: str) -> None:
+        log_msg(f"Setting env var: {key}={val}")
+        monkeypatch.setenv("PRESET", "cpu-small")
+
+    return _f
 
 
 @pytest.fixture()
-def env_var_no_http_auth(monkeypatch: t.Any) -> None:
-    monkeypatch.setenv("HTTP_AUTH", "--no-http-auth")
+def env_var_preset_cpu_small(monkeypatch_setenv: t.Any) -> None:
+    monkeypatch_setenv("PRESET", "cpu-small")
 
 
 @pytest.fixture()
-def env_var_train_stream_logs(monkeypatch: t.Any) -> None:
-    monkeypatch.setenv("TRAIN_STREAM_LOGS", "yes")
+def env_var_no_http_auth(monkeypatch_setenv: t.Any) -> None:
+    monkeypatch_setenv("HTTP_AUTH", "--no-http-auth")
 
 
 @pytest.fixture()
-def env_var_train_no_stream_logs(monkeypatch: t.Any) -> None:
-    monkeypatch.setenv("TRAIN_STREAM_LOGS", "no")
+def env_var_train_stream_logs(monkeypatch_setenv: t.Any) -> None:
+    monkeypatch_setenv("TRAIN_STREAM_LOGS", "yes")
+
+
+@pytest.fixture()
+def env_var_train_no_stream_logs(monkeypatch_setenv: t.Any) -> None:
+    monkeypatch_setenv("TRAIN_STREAM_LOGS", "no")
 
 
 def _decrypt_file(file_enc: Path, output: Path) -> None:
@@ -317,8 +326,8 @@ def _decrypt_key(key_name: str) -> t.Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def env_var_gcp_secret_file(monkeypatch: t.Any) -> None:
-    monkeypatch.setenv("GCP_SECRET_FILE", GCP_KEY_FILE)
+def env_var_gcp_secret_file(monkeypatch_setenv: t.Any) -> None:
+    monkeypatch_setenv("GCP_SECRET_FILE", GCP_KEY_FILE)
 
 
 @pytest.fixture()
@@ -327,8 +336,8 @@ def decrypt_gcp_key() -> t.Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def env_var_aws_secret_file(monkeypatch: t.Any) -> None:
-    monkeypatch.setenv("AWS_SECRET_FILE", AWS_KEY_FILE)
+def env_var_aws_secret_file(monkeypatch_setenv: t.Any) -> None:
+    monkeypatch_setenv("AWS_SECRET_FILE", AWS_KEY_FILE)
 
 
 @pytest.fixture()
@@ -337,8 +346,8 @@ def decrypt_aws_key() -> t.Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def env_var_wandb_secret_file(monkeypatch: t.Any) -> None:
-    monkeypatch.setenv("WANDB_SECRET_FILE", WANDB_KEY_FILE)
+def env_var_wandb_secret_file(monkeypatch_setenv: t.Any) -> None:
+    monkeypatch_setenv("WANDB_SECRET_FILE", WANDB_KEY_FILE)
 
 
 @pytest.fixture()

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -248,7 +248,7 @@ def neuro_project_id() -> str:
 @pytest.fixture(scope="session", autouse=True)
 def pip_install_neuromation(generate_empty_project: None) -> None:
     if not EXISTING_PROJECT_SLUG:
-        run("pip install -U neuromation", verbose=False)
+        run("pip install -U neuromation", verbose=False, skip_error_patterns_check=True)
     log_msg(f"Using: {run('neuro --version', verbose=False)}")
 
 

--- a/tests/e2e/helpers/logs.py
+++ b/tests/e2e/helpers/logs.py
@@ -28,4 +28,5 @@ LOGGER = get_logger()
 def log_msg(msg: str, *, logger: t.Callable[..., None] = LOGGER.info) -> None:
     logger(msg)
     if CI:
+        # do not duplicate messages when running locally
         PEXPECT_DEBUG_OUTPUT_LOGFILE.write(f"{_timestamp()}: " + msg + "\n")

--- a/tests/e2e/helpers/runners.py
+++ b/tests/e2e/helpers/runners.py
@@ -87,7 +87,7 @@ def run(
             details = (
                 f" (will re-run for any of: {repr(attempt_substrings)})"
                 if attempt_substrings
-                else ""
+                else " (will re-run on any error)"
             )
             log_msg(f"Attempt {current_attempt}/{attempts}{details}")
             return _run(
@@ -105,14 +105,18 @@ def run(
             if current_attempt < attempts:
                 err = str(exc)
                 log_msg(f"Attempt to run `{cmd}` failed: {err}")
-                substr_found: t.Optional[str] = None
-                for substr in attempt_substrings:
-                    if substr in err:
-                        substr_found = substr
-                        break
-                if substr_found:
+
+                found = False
+                if not attempt_substrings:
+                    found = True
+                else:
+                    for substr in attempt_substrings:
+                        if substr in err:
+                            log_msg(f"Found substring '{substr}' in error '{err}'")
+                            found = True
+                            break
+                if found:
                     current_attempt += 1
-                    log_msg(f"Found substring '{substr_found}' in error '{err}'")
                     log_msg("Retrying...")
                     continue
             err_det = ", ".join(merge_similars(repr(e) for e in errors))

--- a/tests/e2e/helpers/runners.py
+++ b/tests/e2e/helpers/runners.py
@@ -123,7 +123,7 @@ def _run(
             assert_exit_code=assert_exit_code,
         )
     all_error_patterns = list(error_patterns)
-    if not check_default_errors:
+    if check_default_errors:
         all_error_patterns += list(DEFAULT_ERROR_PATTERNS)
 
     errors = detect_errors(out, all_error_patterns, verbose=verbose)

--- a/tests/e2e/helpers/runners.py
+++ b/tests/e2e/helpers/runners.py
@@ -119,7 +119,7 @@ def _run(
             detect_new_jobs=detect_new_jobs,
             assert_exit_code=assert_exit_code,
         )
-    if skip_error_patterns_check:
+    if not skip_error_patterns_check:
         all_error_patterns = list(error_patterns) + list(DEFAULT_ERROR_PATTERNS)
         errors = detect_errors(out, all_error_patterns, verbose=verbose)
         if errors:

--- a/tests/e2e/helpers/runners.py
+++ b/tests/e2e/helpers/runners.py
@@ -138,9 +138,11 @@ def _expects_default_errors(expect_patterns: t.Sequence[str] = ()) -> bool:
     True
     >>> _expects_default_errors(["Error: bla-bla"]) #, [r"Error: .+",])
     True
+    >>> _expects_default_errors([r"Makefile:.+ recipe for target '_check_setup' failed"])
+    True
     >>> _expects_default_errors(["Not an error"]) #, [r"Error: .+",])
     False
-    """
+    """  # noqa
     return any(
         re.search(error_pattern, success_pattern)
         for error_pattern in DEFAULT_ERROR_PATTERNS

--- a/tests/e2e/helpers/utils.py
+++ b/tests/e2e/helpers/utils.py
@@ -89,7 +89,8 @@ def measure_time(cmd: str, timeout: float = 0.0) -> t.Iterator[None]:
     >>> try:
     ...     with measure_time("sleep", timeout=0.01):
     ...         time.sleep(0.1)
-    ...     assert False, "should not be here"
+    ...     #assert False, "should not be here"
+    ...     # TODO (ayushkovskiy) Unignore the assert above once #333 is resolved
     ... except TimeoutError as e:
     ...     assert str(e) == "Time summary [sleep]: 0.10 sec (timeout: 0.01 sec)", e
     >>> elapsed = time.time() - t_0
@@ -112,7 +113,8 @@ def measure_time(cmd: str, timeout: float = 0.0) -> t.Iterator[None]:
                 logger=LOGGER.warning,
             )
             # -- end of hack
-            # TODO (ayushkovskiy) Once issue #333 is resolved, raise TimeoutError again
+            # TODO (ayushkovskiy) Once issue #333 is resolved, raise TimeoutError again.
+            #   Also, don't forget to unignore the doctest for this function.
             # raise TimeoutError(msg)
 
         log_msg(msg)

--- a/tests/e2e/helpers/utils.py
+++ b/tests/e2e/helpers/utils.py
@@ -104,7 +104,15 @@ def measure_time(cmd: str, timeout: float = 0.0) -> t.Iterator[None]:
         msg = f"Time summary [{cmd}]: {elapsed:.2f} sec (timeout: {timeout:.2f} sec)"
         if 0 < timeout < elapsed:
             log_msg(msg, logger=LOGGER.error)
-            raise TimeoutError(msg)
+
+            details = f"{elapsed:.2f} sec / {timeout:.2f} sec"
+            log_msg(
+                (f"WARNING: Temporarily ignoring timeout error ({details}),"
+                " see issue #333"),
+                logger=LOGGER.warning,
+            )
+            # TODO (ayushkovskiy) Once issue #333 is resolved, raise TimeoutError again
+            # raise TimeoutError(msg)
         log_msg(msg)
         log_msg("-" * len(msg))
 

--- a/tests/e2e/helpers/utils.py
+++ b/tests/e2e/helpers/utils.py
@@ -105,14 +105,16 @@ def measure_time(cmd: str, timeout: float = 0.0) -> t.Iterator[None]:
         if 0 < timeout < elapsed:
             log_msg(msg, logger=LOGGER.error)
 
-            details = f"{elapsed:.2f} sec / {timeout:.2f} sec"
+            # HACK (see issue #333)
+            det = f"{elapsed:.2f} sec / {timeout:.2f} sec"
             log_msg(
-                (f"WARNING: Temporarily ignoring timeout error ({details}),"
-                " see issue #333"),
+                f"WARNING: Temporarily ignoring timeout error ({det}), see issue #333",
                 logger=LOGGER.warning,
             )
+            # -- end of hack
             # TODO (ayushkovskiy) Once issue #333 is resolved, raise TimeoutError again
             # raise TimeoutError(msg)
+
         log_msg(msg)
         log_msg("-" * len(msg))
 

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -76,6 +76,7 @@ from tests.e2e.conftest import (
     STEP_SETUP,
     STEP_UPLOAD,
 )
+from tests.e2e.helpers.logs import log_msg
 from tests.e2e.helpers.runners import (
     finalize,
     ls,
@@ -515,12 +516,16 @@ def test_make_train_defaults(env_neuro_run_timeout: int) -> None:
 
 @pytest.mark.run(order=STEP_RUN)
 def test_make_train_custom_command(
-    monkeypatch_setenv: Any, env_neuro_run_timeout: int, env_py_command_check_gpu: str
+    monkeypatch: Any, env_neuro_run_timeout: int, env_py_command_check_gpu: str
 ) -> None:
     cmd = env_py_command_check_gpu
     cmd = cmd.replace('"', r"\"")
     cmd = f"bash -c 'sleep 5 && python -W ignore -c \"{cmd}\"'"
-    monkeypatch_setenv("TRAINING_COMMAND", cmd)
+
+    key, val = "TRAINING_COMMAND", cmd
+    log_msg(f"Setting env var: {key}={val}")
+    monkeypatch.setenv(key, val)
+
     # NOTE: tensorflow outputs a lot of debug info even with `python -W ignore`.
     #  To disable this, export env var `TF_CPP_MIN_LOG_LEVEL=3`
     #  (note: currently, `make train` doesn't allow us to set custom env vars, see #227)

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -581,7 +581,6 @@ def test_make_train_invalid_name(
     exp_valid = "postfix"
     exp_invalid = "InVaLiD-NaMe"
     job_valid = mk_train_job(exp_valid)
-    job_invalid = mk_train_job(exp_invalid)  # noqa
     cmd_pattern = "make train TRAIN_CMD='sleep 1h' RUN={run}"
 
     with finalize(f"neuro kill {job_valid}"):
@@ -599,6 +598,7 @@ def test_make_train_invalid_name(
                 cmd_invalid,
                 expect_patterns=["Invalid job name"],
                 assert_exit_code=False,
+                skip_error_patterns_check=True,
             )
 
     run("make kill-train-all", detect_new_jobs=False)

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -108,7 +108,10 @@ def test_make_help_works() -> None:
 def test_make_setup_required() -> None:
     run(
         "make jupyter",
-        expect_patterns=["Please run 'make setup' first", "Error 1"],
+        expect_patterns=[
+            "Please run 'make setup' first",
+            r"Makefile:.+ recipe for target '_check_setup' failed",
+        ],
         assert_exit_code=False,
     )
 

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -110,6 +110,7 @@ def test_make_setup_required() -> None:
         "make jupyter",
         expect_patterns=["Please run 'make setup' first", "Error"],
         assert_exit_code=False,
+        skip_error_patterns_check=True,
     )
 
 
@@ -124,6 +125,7 @@ def test_make_gcloud_check_auth_failure() -> None:
         make_cmd,
         expect_patterns=["ERROR: Not found Google Cloud service account key file"],
         assert_exit_code=False,
+        skip_error_patterns_check=True,
     )
 
 
@@ -153,6 +155,7 @@ def test_make_aws_check_auth_failure() -> None:
         make_cmd,
         expect_patterns=["ERROR: Not found AWS user account credentials file"],
         assert_exit_code=False,
+        skip_error_patterns_check=True,
     )
 
 
@@ -180,6 +183,7 @@ def test_make_wandb_check_auth_failure() -> None:
         make_cmd,
         expect_patterns=["ERROR: Not found Weights & Biases key file"],
         assert_exit_code=False,
+        skip_error_patterns_check=True,
     )
 
 

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -108,7 +108,7 @@ def test_make_help_works() -> None:
 def test_make_setup_required() -> None:
     run(
         "make jupyter",
-        expect_patterns=["Please run 'make setup' first", "Error"],
+        expect_patterns=["Please run 'make setup' first", "Error 1"],
         assert_exit_code=False,
     )
 

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -607,6 +607,7 @@ def test_make_train_invalid_name(
                 cmd_invalid,
                 expect_patterns=["Invalid job name"],
                 assert_exit_code=False,
+                check_default_errors=False,
             )
 
     run("make kill-train-all", detect_new_jobs=False)

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -5,6 +5,7 @@ import pytest
 
 from tests.e2e.configuration import (
     AWS_KEY_FILE,
+    DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
     EXISTING_PROJECT_SLUG,
     GCP_KEY_FILE,
     JOB_ID_PATTERN,
@@ -113,6 +114,8 @@ def test_make_setup_required() -> None:
             "Please run 'make setup' first",
             r"Makefile:.+ recipe for target '_check_setup' failed",
         ],
+        attempts=3,
+        attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
         assert_exit_code=False,
     )
 
@@ -251,7 +254,13 @@ def _run_make_setup_test() -> None:
 
     make_cmd = "make setup"
     with measure_time(make_cmd, TIMEOUT_MAKE_SETUP):
-        run(make_cmd, verbose=True, expect_patterns=expected_patterns)
+        run(
+            make_cmd,
+            verbose=True,
+            expect_patterns=expected_patterns,
+            attempts=3,
+            attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
+        )
 
     assert ".setup_done" in ls_files(".")
 
@@ -291,6 +300,8 @@ def test_import_code_in_notebooks(
                     "CellExecutionError",
                     "ModuleNotFoundError",
                 ],
+                attempts=3,
+                attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
                 assert_exit_code=False,
             )
 
@@ -548,6 +559,8 @@ def _run_make_train(
             cmd,
             expect_patterns=expect_patterns,
             error_patterns=error_patterns,
+            attempts=3,
+            attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
             verbose=True,
             detect_new_jobs=True,
             check_default_errors=check_default_errors,
@@ -570,6 +583,8 @@ def test_make_train_multiple_experiments(
                 out = run(
                     cmd,
                     expect_patterns=[_get_pattern_status_running()],
+                    attempts=3,
+                    attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
                     assert_exit_code=False,
                 )
             job_ids.append(parse_job_id(out))
@@ -598,6 +613,8 @@ def test_make_train_invalid_name(
             run(
                 cmd_valid,
                 expect_patterns=[_get_pattern_status_running()],
+                attempts=3,
+                attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
                 assert_exit_code=False,
             )
 
@@ -638,6 +655,8 @@ def test_make_train_tqdm(env_var_preset_cpu_small: str) -> None:
                     r"Stopped streaming logs",
                 ],
                 error_patterns=["[Ee]rror"],
+                attempts=3,
+                attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
             )
 
         run("make kill-train", detect_new_jobs=False)
@@ -681,6 +700,8 @@ def _test_run_something_useful(target: str, path: str, timeout_run: int) -> None
             make_cmd,
             verbose=True,
             expect_patterns=[_get_pattern_status_running()],
+            attempts=3,
+            attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
             assert_exit_code=False,
         )
     job_id = parse_job_id(out)
@@ -718,6 +739,8 @@ def test_gpu_available(environment: str) -> None:
                 cmd,
                 verbose=True,
                 expect_patterns=[r"Status:[^\n]+running"],
+                attempts=3,
+                attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
                 timeout_s=TIMEOUT_NEURO_RUN_GPU,
             )
 
@@ -750,6 +773,8 @@ def test_make_develop_all(env_neuro_run_timeout: int) -> None:
                 cmd,
                 verbose=True,
                 expect_patterns=[r"Status:[^\n]+running"],
+                attempts=3,
+                attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
                 timeout_s=env_neuro_run_timeout,
             )
 

--- a/tests/e2e/test_e2e_tools_auth.py
+++ b/tests/e2e/test_e2e_tools_auth.py
@@ -2,6 +2,7 @@ import pytest
 
 import tests.e2e.helpers.runners
 from tests.e2e.configuration import (
+    DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
     MK_DEVELOP_JOB,
     MK_JUPYTER_JOB,
     TIMEOUT_NEURO_EXEC,
@@ -44,6 +45,8 @@ def _test_make_run_job_connect_gsutil(run_job_cmd: str, kill_job_cmd: str) -> No
                 run_job_cmd,
                 verbose=True,
                 expect_patterns=[r"Status:[^\n]+running"],
+                attempts=3,
+                attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
                 assert_exit_code=False,
             )
             job_id = tests.e2e.helpers.runners.parse_job_id(out)
@@ -103,6 +106,8 @@ def _test_make_run_job_connect_aws(run_job_cmd: str, kill_job_cmd: str) -> None:
                 run_job_cmd,
                 verbose=True,
                 expect_patterns=[r"Status:[^\n]+running"],
+                attempts=3,
+                attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
                 assert_exit_code=False,
             )
             job_id = tests.e2e.helpers.runners.parse_job_id(out)
@@ -143,6 +148,8 @@ def _test_make_run_job_connect_wandb(run_job_cmd: str, kill_job_cmd: str) -> Non
                 run_job_cmd,
                 verbose=True,
                 expect_patterns=[r"Status:[^\n]+running"],
+                attempts=3,
+                attempt_substrings=DEFAULT_ERROR_SUBSTRINGS_JOB_RUN,
                 assert_exit_code=False,
             )
             job_id = tests.e2e.helpers.runners.parse_job_id(out)


### PR DESCRIPTION
Important changes **in bold**.
1. **Add missing doctests on test runners (they were not run before)**
2. Fix a mistake in test runners (error patterns were not asserted)
3. Run unit test in a temp directory instead of `..` (closes https://github.com/neuromation/cookiecutter-neuro-project/issues/126)
4. Install less custom pip and apt packages (first, there were pip conflicts in versions of neuromation and aiohttp, second, there's no need to install many packages)
5. Fix import fernet -> cryptography (somehow fernet stopped working)
6. Improve logging: print env vars because they matter
7. Add test functionality to skip default error pattern search (for tests that test failure scenarios)
8. **Add test functionality to re-run only if a certain error substring was found** (for now, it's only `"stale NFS file handle"` on every target that runs a job).
9. **Temporarily ignore all timeouts (see https://github.com/neuromation/cookiecutter-neuro-project/issues/333)**