### PR TITLE
[Template] Change default project name

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-    "project_name": "Name of the project",
+    "project_name": "Neuro Project",
     "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '-').replace('_', '-') }}",
     "code_directory": "modules"
 }


### PR DESCRIPTION
default project slug `name-of-the-project` is too long, for this, jobs run with hypertrain fail of too long job name.