### PR TITLE
[tests] Fix test on Linux

### DIFF
--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -729,7 +729,7 @@ def test_gpu_available(environment: str) -> None:
         for py in py_commands:
             cmd = (
                 f"neuro exec --no-key-check --no-tty {MK_DEVELOP_JOB} "
-                f'"python -c \\"{py}\\""'
+                f'"python -c \'{py}\'"'
             )
             with measure_time(cmd):
                 run(cmd, attempts=2, timeout_s=TIMEOUT_NEURO_EXEC)

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -729,7 +729,7 @@ def test_gpu_available(environment: str) -> None:
         for py in py_commands:
             cmd = (
                 f"neuro exec --no-key-check --no-tty {MK_DEVELOP_JOB} "
-                f'"python -c \'{py}\'"'
+                f"\"python -c '{py}'\""
             )
             with measure_time(cmd):
                 run(cmd, attempts=2, timeout_s=TIMEOUT_NEURO_EXEC)


### PR DESCRIPTION
https://dev.azure.com/neuromation/cookiecutter-neuro-project/_build/results?buildId=2533&view=logs&j=63c7865a-3588-542b-203b-b65599712d82&t=12cdcf0a-6d87-5aaf-034b-f05b1d42dfa8
```
2020-02-27T21:10:38.0826193Z tests/e2e/test_e2e_template.py::test_gpu_available 
2020-02-27T21:10:38.0828186Z 00:00.001 inf e2e: Measuring time for command: `make develop PRESET=gpu-small`
2020-02-27T21:10:38.0830711Z 00:00.001 inf e2e: Attempt 1/3 (will re-run for any of: ['stale NFS file handle'])
2020-02-27T21:10:38.0832054Z 00:00.001 inf e2e: <<< make develop PRESET=gpu-small
2020-02-27T21:10:38.1083867Z 00:00.026 inf e2e: Search patterns: ['Status:[^\\n]+running']
2020-02-27T21:10:55.1898089Z 00:17.107 inf e2e: Found expected pattern: 'Status:[^\\n]+running'
2020-02-27T21:10:55.2582025Z 00:17.176 inf e2e: Waiting for 'make develop PRESET=gpu-small'
2020-02-27T21:10:55.3594485Z 00:17.277 inf e2e: Dumped jobs: {'job-794547b2-e170-4bd2-99fb-6ae925d2da1d'}
2020-02-27T21:10:55.3602283Z 00:17.278 inf e2e: ---------------------------------------------------------------------------
2020-02-27T21:10:55.3606041Z 00:17.278 inf e2e: Measuring time for command: `neuro exec --no-key-check --no-tty develop-test-project-b5d92343 "python -c \"import tensorflow as tf; assert tf.test.is_gpu_available()\""`
2020-02-27T21:10:55.3608840Z 00:17.279 inf e2e: Attempt 1/2 (will re-run on any error)
2020-02-27T21:10:55.3610931Z 00:17.279 inf e2e: <<< neuro exec --no-key-check --no-tty develop-test-project-b5d92343 "python -c \"import tensorflow as tf; assert tf.test.is_gpu_available()\""
2020-02-27T21:10:56.3202257Z 00:18.237 inf e2e: Waiting for 'neuro exec --no-key-check --no-tty develop-test-project-b5d92343 "python -c \"import tensorflow as tf; assert tf.test.is_gpu_available()\""'
2020-02-27T21:10:56.4218574Z 00:18.339 inf e2e: DUMP: '\x1b[31mERROR\x1b[0m: No closing quotation\r\n'
2
```