### PR TITLE
[Makefile] Use shorter name for N_HYPERPARAM_JOBS argument

### DIFF
--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -590,7 +590,7 @@ def test_make_hypertrain(
     n = 2
     with finalize("make kill-hypertrain-all"):
         out = run(
-            f"make hypertrain N_HYPERPARAM_JOBS={n}",
+            f"make hypertrain N_JOBS={n}",
             expect_patterns=(
                 [_get_pattern_status_running()] * n
                 + [f"Started {n} hyper-parameter search jobs"]

--- a/{{cookiecutter.project_slug}}/HELP.md
+++ b/{{cookiecutter.project_slug}}/HELP.md
@@ -281,6 +281,6 @@ This list of hyper-parameters corresponds to the default configuration we provid
 
 You also need to put your WandB token in `config/wandb-token.txt` file.
 
-After that, you can run `make hypertrain`, which submits `N_HYPERPARAMETER_JOBS` (`3` by default) jobs on Neuro Platform (number of jobs can be modified in `Makefile` or as corresponding environment variable). To monitor the hyperparameter tuning process, follow the link which `wandb` provides at the beginning of the process.
+After that, you can run `make hypertrain`, which submits `N_JOBS` (`3` by default) jobs on Neuro Platform (number of jobs can be modified in `Makefile` or as corresponding environment variable). Use `make ps-hypertrain` to list active jobs of the latest sweep. To monitor the hyperparameter tuning process, follow the link which `wandb` provides at the beginning of the process.
 
 To terminate all jobs over all hyperparameter tuning sweeps, run `make kill-hypertrain-all`. After that, verify that the jobs were killed `make ps`, and then delete unused sweeps from the local file `.wandb_sweeps`.

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -80,8 +80,8 @@ LOCAL_PORT?=2211
 JUPYTER_MODE?=notebook
 
 # Number of hyper-parameter search jobs:
-#   make hypertrain N_HYPERPARAM_JOBS=5
-N_HYPERPARAM_JOBS?=3
+#   make hypertrain N_JOBS=5
+N_JOBS?=3
 
 # Google Cloud integration settings:
 #   make gcloud-check-auth GCP_SECRET_FILE=name-of-gcp-key-file.json
@@ -411,8 +411,8 @@ hypertrain: _check_setup wandb-check-auth   ### Run jobs in parallel for hyperpa
 	$(NEURO) cp ./wandb/settings $(PROJECT_PATH_STORAGE)/wandb/
 	sweep=`tail -1 $(WANDB_SWEEPS_FILE)` && \
 	$(NEURO) mkdir -p $(PROJECT_PATH_STORAGE)/$(RESULTS_DIR)/sweep-$$sweep && \
-	echo "Running $(N_HYPERPARAM_JOBS) jobs of sweep '$$sweep'..." && \
-	for index in `seq 1 $(N_HYPERPARAM_JOBS)` ; do \
+	echo "Running $(N_JOBS) jobs of sweep '$$sweep'..." && \
+	for index in `seq 1 $(N_JOBS)` ; do \
 		echo -e "\nStarting job $$index..." ; \
 		$(NEURO) run $(RUN_EXTRA) \
 			--name $(TRAIN_JOB)-$$sweep-$$index \
@@ -431,7 +431,7 @@ hypertrain: _check_setup wandb-check-auth   ### Run jobs in parallel for hyperpa
 			$(CUSTOM_ENV) \
 			bash -c "export WANDB_PROJECT=$(PROJECT) && cd $(PROJECT_PATH_ENV) && wandb status && wandb agent $$sweep"; \
 	done; \
-	echo -e "\nStarted $(N_HYPERPARAM_JOBS) hyper-parameter search jobs of sweep '$$sweep'.\nUse 'neuro ps' and 'neuro status <job>' to check."
+	echo -e "\nStarted $(N_JOBS) hyper-parameter search jobs of sweep '$$sweep'.\nUse 'neuro ps' and 'neuro status <job>' to check."
 
 .PHONY: kill-hypertrain-all
 kill-hypertrain-all:  ### Terminate all hyper-parameter search training jobs of all the sweeps

--- a/{{cookiecutter.project_slug}}/requirements.txt
+++ b/{{cookiecutter.project_slug}}/requirements.txt
@@ -1,4 +1,4 @@
-neuromation==20.3.23
+neuromation>=20.4.6
 wandb==0.8.28
 flake8
 mypy


### PR DESCRIPTION
I always forget how it's called. `N_JOBS` is shorter and easier to remember.