### PR TITLE
[Makefile] Sync directories optionally

### DIFF
--- a/{{cookiecutter.project_slug}}/HELP.md
+++ b/{{cookiecutter.project_slug}}/HELP.md
@@ -219,6 +219,13 @@ There are several machine types supported on the platform. Run `neuro config sho
 
 When jobs with HTTP interface are executed (for example, with Jupyter Notebooks or TensorBoard), this interface requires a user to be authenticated on the platform. However, if you want to share the link with someone who is not registered on the platform, you may disable the authentication updating this line to `HTTP_AUTH?=--no-http-auth`.
 
+### Storage synchronization
+
+By default, `develop`, `train` and `jupyter` commands sync code, config and notebooks directories before start.
+To control this, see `SYNC` environment variable:
+
+`make train SYNC=''  # will not sync` 
+
 ### Training command
 
 To tweak the training command, change the line in `Makefile`:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -103,6 +103,9 @@ WANDB_SECRET_FILE?=wandb-token.txt
 #   make hypertrain WANDB_SECRET_FILE=name-of-wandb-sweep-file.json
 WANDB_SWEEP_CONFIG_FILE?=wandb-sweep.yaml
 
+# Storage synchronization:
+#  make jupyter SYNC=""
+SYNC?=upload-code upload-config upload-notebooks
 
 ##### CONSTANTS #####
 
@@ -336,7 +339,7 @@ wandb-check-auth:  ### Check if the file Weights and Biases authentication file 
 ##### JOBS #####
 
 .PHONY: develop
-develop: _check_setup upload-code upload-config upload-notebooks  ### Run a development job
+develop: _check_setup $(SYNC)  ### Run a development job
 	$(NEURO) run $(RUN_EXTRA) \
 		--name $(DEVELOP_JOB) \
 		--tag "target:develop" $(_PROJECT_TAGS) \
@@ -371,7 +374,7 @@ kill-develop:  ### Terminate the development job
 	$(NEURO) kill $(DEVELOP_JOB) || :
 
 .PHONY: train
-train: _check_setup upload-code upload-config   ### Run a training job (set up env var 'RUN' to specify the training job),
+train: _check_setup $(SYNC)   ### Run a training job (set up env var 'RUN' to specify the training job),
 	$(NEURO) run $(RUN_EXTRA) \
 		--name $(TRAIN_JOB)-$(RUN) \
 		--tag "target:train" $(_PROJECT_TAGS) \
@@ -460,7 +463,7 @@ connect-train: _check_setup  ### Connect to the remote shell running on the trai
 	$(NEURO) exec --no-key-check $(TRAIN_JOB)-$(RUN) bash
 
 .PHONY: jupyter
-jupyter: _check_setup upload-config upload-code upload-notebooks ### Run a job with Jupyter Notebook and open UI in the default browser
+jupyter: _check_setup $(SYNC) ### Run a job with Jupyter Notebook and open UI in the default browser
 	$(NEURO) run $(RUN_EXTRA) \
 		--name $(JUPYTER_JOB) \
 		--tag "target:jupyter" $(_PROJECT_TAGS) \


### PR DESCRIPTION
When [debugging](https://github.com/neuromation/ml-recipe-project-zero/pull/1) `make train` in Project Zero, I felt annoyance while waiting for all directories to sync before the job starts (and usually fails). So I'd like to have control to temporarily disable sync.


Closes https://github.com/neuromation/cookiecutter-neuro-project/issues/118 with a compromise solution: 

```
$ make train  # syncs
$ make train SYNC=''  # does not sync
$ export SYNC=''
$ make train  # does not sync
```