### PR TITLE
[Makefile] Add VSCode target!

### DIFF
--- a/tests/e2e/configuration.py
+++ b/tests/e2e/configuration.py
@@ -68,6 +68,7 @@ MK_DEVELOP_JOB = f"develop-{MK_PROJECT}"
 MK_JUPYTER_JOB = f"jupyter-{MK_PROJECT}"
 MK_TENSORBOARD_JOB = f"tensorboard-{MK_PROJECT}"
 MK_FILEBROWSER_JOB = f"filebrowser-{MK_PROJECT}"
+MK_VSCODE_JOB = f"vscode-{MK_PROJECT}"
 
 MK_RUN_DEFAULT = "base"  # env var 'RUN'
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,8 +8,8 @@ from collections import namedtuple
 from pathlib import Path
 
 import pytest
-from cryptography.fernet import Fernet
 
+from cryptography.fernet import Fernet
 from tests.e2e.configuration import (
     AWS_KEY_FILE,
     EXISTING_PROJECT_SLUG,

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,8 +8,8 @@ from collections import namedtuple
 from pathlib import Path
 
 import pytest
-
 from cryptography.fernet import Fernet
+
 from tests.e2e.configuration import (
     AWS_KEY_FILE,
     EXISTING_PROJECT_SLUG,

--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -25,6 +25,7 @@ from tests.e2e.configuration import (
     MK_RUN_DEFAULT,
     MK_SETUP_JOB,
     MK_TENSORBOARD_JOB,
+    MK_VSCODE_JOB,
     N_FILES,
     PACKAGES_APT_CUSTOM,
     PACKAGES_PIP_CUSTOM,
@@ -644,6 +645,12 @@ def test_make_filebrowser(env_var_no_http_auth: None) -> None:
         _test_run_something_useful(
             "filebrowser", "/files/requirements.txt", TIMEOUT_NEURO_RUN_CPU
         )
+
+
+@pytest.mark.run(order=STEP_RUN)
+def test_make_vscode(env_var_no_http_auth: None) -> None:
+    with finalize(f"neuro kill {MK_VSCODE_JOB}"):
+        _test_run_something_useful("vscode", "/", TIMEOUT_NEURO_RUN_CPU)
 
 
 def _test_run_something_useful(target: str, path: str, timeout_run: int) -> None:

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -55,7 +55,7 @@ PRESET?=gpu-small
 RUN_EXTRA?=
 
 # HTTP authentication (via cookies) for the job's HTTP link.
-# Applied only to jupyter, tensorboard and filebrowser jobs.
+# Applied only to jupyter, vscode, tensorboard and filebrowser jobs.
 # Set `HTTP_AUTH=--no-http-auth` to disable any authentication.
 # WARNING: removing authentication might disclose your sensitive data stored in the job.
 #   make jupyter HTTP_AUTH=--no-http-auth
@@ -343,6 +343,7 @@ vscode: _check_setup upload-code upload-config  ### Run a VSCode job
 		--name $(VSCODE_JOB) \
 		--tag "target:vscode" $(_PROJECT_TAGS) \
 		--preset $(PRESET) \
+		$(HTTP_AUTH) \
 		--http 8080 \
 		--browse \
 		--detach \

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -16,6 +16,7 @@ PROJECT_PATH_ENV=/project
 PROJECT={{cookiecutter.project_slug}}
 SETUP_JOB=setup-$(PROJECT)
 TRAIN_JOB=train-$(PROJECT)
+VSCODE_JOB=vscode-$(PROJECT)
 DEVELOP_JOB=develop-$(PROJECT)
 JUPYTER_JOB=jupyter-$(PROJECT)
 TENSORBOARD_JOB=tensorboard-$(PROJECT)
@@ -334,6 +335,31 @@ wandb-check-auth:  ### Check if the file Weights and Biases authentication file 
 			false; }
 
 ##### JOBS #####
+
+.PHONY: vscode
+vscode: PRESET=cpu-small
+vscode: _check_setup upload-code upload-config  ### Run a VSCode job
+	$(NEURO) run $(RUN_EXTRA) \
+		--name $(VSCODE_JOB) \
+		--tag "target:vscode" $(_PROJECT_TAGS) \
+		--preset $(PRESET) \
+		--http 8080 \
+		--browse \
+		--detach \
+		--volume $(PROJECT_PATH_STORAGE):$(PROJECT_PATH_ENV):rw \
+		--env PYTHONPATH=$(PROJECT_PATH_ENV) \
+		--env EXPOSE_SSH=yes \
+		--life-span=1d \
+		--entrypoint="sudo dumb-init fixuid -q /usr/local/bin/code-server --host 0.0.0.0 ." \
+		codercom/code-server \
+		    --disable-updates \
+		    --disable-telemetry \
+		    --auth=none \
+		    $(PROJECT_PATH_ENV)
+
+.PHONY: kill-vscode
+kill-vscode: download-code download-config download-results  ### Terminate the VSCode job
+	$(NEURO) kill $(VSCODE_JOB)
 
 .PHONY: develop
 develop: _check_setup upload-code upload-config upload-notebooks  ### Run a development job

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -351,15 +351,15 @@ vscode: _check_setup upload-code upload-config  ### Run a VSCode job
 		--env PYTHONPATH=$(PROJECT_PATH_ENV) \
 		--env EXPOSE_SSH=yes \
 		--life-span=1d \
-		--entrypoint="sudo dumb-init fixuid -q /usr/local/bin/code-server --host 0.0.0.0 ." \
-		codercom/code-server \
+		--entrypoint="sudo dumb-init fixuid -q /usr/bin/code-server --host 0.0.0.0 ." \
+		codercom/code-server:3.3.0-rc.7 \
 		    --disable-updates \
 		    --disable-telemetry \
 		    --auth=none \
 		    $(PROJECT_PATH_ENV)
 
 .PHONY: kill-vscode
-kill-vscode: download-code download-config download-results  ### Terminate the VSCode job
+kill-vscode:  ### Terminate the VSCode job
 	$(NEURO) kill $(VSCODE_JOB)
 
 .PHONY: develop


### PR DESCRIPTION
Project's storage directory mounted to the job serving VS Code Server.

![image](https://user-images.githubusercontent.com/7501517/78831802-eccb1480-79f2-11ea-80fa-fcb17cdb57f8.png)


Multiple extensions supported, including:
- [Remote debugging](https://code.visualstudio.com/docs/editor/debugging),
- [Connect to remote Docker host](https://code.visualstudio.com/docs/remote/containers) to develop right inside it,
- [Path auto-completion](https://marketplace.visualstudio.com/items?itemName=christian-kohler.path-intellisense),
- [Python auto-completion](https://marketplace.visualstudio.com/items?itemName=ms-python.python) and [here](https://marketplace.visualstudio.com/items?itemName=VisualStudioExptTeam.vscodeintellicode)