### PR TITLE
[Makefile] Stabilize W&B Hypertrain + Set up CI for MacOS

### DIFF
--- a/.azure-pipelines/stage-e2e.yml
+++ b/.azure-pipelines/stage-e2e.yml
@@ -12,6 +12,9 @@ stages:
         Py37-Win64:
           python.version: '3.7'
           image: 'vs2017-win2016'
+        Py37-MacOS:
+          python.version: '3.7'
+          image: 'macos-latest'
 
     pool:
       vmImage: $[ variables['image'] ]

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -15,6 +15,9 @@
 # Weights & Biases folders
 wandb/
 
+# awk
+awkvars.out*
+
 # Mac OS: Finder's system file
 .DS_Store
 

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -412,7 +412,8 @@ hypertrain: _check_setup wandb-check-auth   ### Run jobs in parallel for hyperpa
 	@[ -f "$(WANDB_SWEEP_CONFIG_PATH)" ] \
 		&& echo "Using W&B sweep file: ./$(WANDB_SWEEP_CONFIG_PATH)" \
 		|| { echo "ERROR: W&B sweep config file not found: '$$PWD/$(WANDB_SWEEP_CONFIG_PATH)'" >&2; false; }
-	WANDB_PROJECT=$(PROJECT) wandb sweep $(WANDB_SWEEP_CONFIG_PATH) 2>&1 | tee -a $(WANDB_SWEEPS_FILE).log | grep 'Created sweep with ID: ' | awk 'NF{ print $$NF }' >> $(WANDB_SWEEPS_FILE)
+	sweep=`WANDB_PROJECT=$(PROJECT) wandb sweep $(WANDB_SWEEP_CONFIG_PATH) 2>&1 | tee -a $(WANDB_SWEEPS_FILE).log | awk '/sweep with ID/{ print $$NF }'` && \
+	echo "sweep: $$sweep" && [ "$$sweep" ] && echo $$sweep >> $(WANDB_SWEEPS_FILE)
 	@echo "Sweep created and saved to '$(WANDB_SWEEPS_FILE)'"
 	@echo "Updating code and config directories on Neuro Storage..."
 	$(NEURO) cp --recursive --update --no-target-directory $(CODE_DIR) $(PROJECT_PATH_STORAGE)/$(CODE_DIR)
@@ -421,7 +422,7 @@ hypertrain: _check_setup wandb-check-auth   ### Run jobs in parallel for hyperpa
 	$(NEURO) mkdir -p $(PROJECT_PATH_STORAGE)/wandb
 	$(NEURO) cp ./wandb/settings $(PROJECT_PATH_STORAGE)/wandb/
 	sweep=`tail -1 $(WANDB_SWEEPS_FILE)` && \
-	echo "$$sweep" && [ "$$sweep" ] && \
+	echo "sweep: $$sweep" && [ "$$sweep" ] && \
 	$(NEURO) mkdir -p $(PROJECT_PATH_STORAGE)/$(RESULTS_DIR)/sweep-$$sweep && \
 	echo "Running $(N_JOBS) jobs of sweep '$$sweep'..." && \
 	for index in `seq 1 $(N_JOBS)` ; do \

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -412,7 +412,7 @@ hypertrain: _check_setup wandb-check-auth   ### Run jobs in parallel for hyperpa
 	@[ -f "$(WANDB_SWEEP_CONFIG_PATH)" ] \
 		&& echo "Using W&B sweep file: ./$(WANDB_SWEEP_CONFIG_PATH)" \
 		|| { echo "ERROR: W&B sweep config file not found: '$$PWD/$(WANDB_SWEEP_CONFIG_PATH)'" >&2; false; }
-	WANDB_PROJECT=$(PROJECT) wandb sweep $(WANDB_SWEEP_CONFIG_PATH) 2>&1 | tee /proc/self/fd/2 | grep 'Created sweep with ID: ' | awk 'NF{ print $$NF }' >> $(WANDB_SWEEPS_FILE)
+	WANDB_PROJECT=$(PROJECT) wandb sweep $(WANDB_SWEEP_CONFIG_PATH) 2>&1 | tee -a $(WANDB_SWEEPS_FILE).log | grep 'Created sweep with ID: ' | awk 'NF{ print $$NF }' >> $(WANDB_SWEEPS_FILE)
 	@echo "Sweep created and saved to '$(WANDB_SWEEPS_FILE)'"
 	@echo "Updating code and config directories on Neuro Storage..."
 	$(NEURO) cp --recursive --update --no-target-directory $(CODE_DIR) $(PROJECT_PATH_STORAGE)/$(CODE_DIR)

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -421,6 +421,7 @@ hypertrain: _check_setup wandb-check-auth   ### Run jobs in parallel for hyperpa
 	$(NEURO) mkdir -p $(PROJECT_PATH_STORAGE)/wandb
 	$(NEURO) cp ./wandb/settings $(PROJECT_PATH_STORAGE)/wandb/
 	sweep=`tail -1 $(WANDB_SWEEPS_FILE)` && \
+	echo "$$sweep" && [ "$$sweep" ] && \
 	$(NEURO) mkdir -p $(PROJECT_PATH_STORAGE)/$(RESULTS_DIR)/sweep-$$sweep && \
 	echo "Running $(N_JOBS) jobs of sweep '$$sweep'..." && \
 	for index in `seq 1 $(N_JOBS)` ; do \


### PR DESCRIPTION
Problems:
1. some macs don't have `/proc/self/fd/2`
2. some `wandb` printed `Create sweep with ID: ...` instead of `Created sweep with ID: ...` so grep was failing
3. removed `grep` in piped operation since even if it failed, the pipe execution was continuing to `awk`