### PR TITLE
[Makefile] No upload-notebooks before each command

### DIFF
--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -105,7 +105,7 @@ WANDB_SWEEP_CONFIG_FILE?=wandb-sweep.yaml
 
 # Storage synchronization:
 #  make jupyter SYNC=""
-SYNC?=upload-code upload-config upload-notebooks
+SYNC?=upload-code upload-config
 
 ##### CONSTANTS #####
 


### PR DESCRIPTION
when working with jupyter, its state is not always sync'ed to the storage (you need to press Ctrl+S to save it). So when `upload-notebooks` is called automatically as a dependency for another command, you might overwrite the remote version of the notebook with the outdated local version.

Another use-case is when you open a jupyter locally and it changes its modification date.