### PR TITLE
Drop filebrowser test

### DIFF
--- a/tests/e2e/test_e2e_template.py
+++ b/tests/e2e/test_e2e_template.py
@@ -12,7 +12,6 @@ from tests.e2e.configuration import (
     JOB_STATUS_SUCCEEDED,
     MK_CODE_DIR,
     MK_DEVELOP_JOB,
-    MK_FILEBROWSER_JOB,
     MK_JUPYTER_JOB,
     MK_NOTEBOOKS_DIR,
     MK_PROJECT,
@@ -213,13 +212,6 @@ def test_make_jupyter_lab(env_var_no_http_auth: None,) -> None:
 @pytest.mark.run(order=STEP_RUN)
 def test_make_tensorboard(env_var_no_http_auth: None) -> None:
     _test_run_something_useful("tensorboard", MK_TENSORBOARD_JOB, "/")
-
-
-@pytest.mark.run(order=STEP_RUN)
-def test_make_filebrowser(env_var_no_http_auth: None) -> None:
-    _test_run_something_useful(
-        "filebrowser", MK_FILEBROWSER_JOB, "/files/requirements.txt"
-    )
 
 
 def _test_run_something_useful(target: str, job_name: str, path: str) -> None:


### PR DESCRIPTION
It [flakes](https://dev.azure.com/neuromation/cookiecutter-neuro-project/_build/results?buildId=4339&view=logs&j=4db9e34a-a06b-5cd0-72b0-15645ff85cca&t=a49aa7d9-d43a-5ff3-059f-2ed74bab9163) a lot:
```
neuro --verbose --show-traceback --color=no run --tag=build-4339 \
		 \
		--name filebrowser-test-project-4c33982c \
		--tag "target:filebrowser" --tag "kind:project" --tag "project:test-project-4c33982c" --tag "project-id:neuro-project-b77256af" \
		--preset cpu-small \
		--http 80 \
		--no-http-auth \
		--browse \
		--life-span=1d \
		--volume storage:test-project-4c33982c:/srv:rw \
		filebrowser/filebrowser:latest \
		--noauth
Using preset 'cpu-small': Preset(cpu=1, memory_mb=4096, is_preemptible=False, gpu=None, gpu_model=None, tpu_type=None, tpu_software_version=None)
Using image 'filebrowser/filebrowser:latest'
Using volumes: 
  'storage://neuro-public/cookiecutter-e2e/test-project-4c33982c' mounted to '/srv' in rw mode
âˆš Job ID: job-86c45526-e875-4269-8a3e-4823e5e9445b 
âˆš Name: filebrowser-test-project-4c33982c
- Status: pending Creating
- Status: pending Creating â—¢ [0.7 sec]
- Status: pending Creating â—£ [1.1 sec]
...
- Status: pending Creating â—¥ [8.6 sec]
- Status: pending Creating
âˆš Status: succeeded
```
Why? who knows.